### PR TITLE
Include prep step

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -1,6 +1,7 @@
 ;; Further info: https://clojure.org/guides/tools_build#_mixed_java_clojure_build
 
 (ns build
+  (:refer-clojure :exclude [compile])
   (:require
    [clojure.java.shell :as sh]
    [clojure.string :as str]

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,10 @@
 {:paths
- ["src" "java" "resources" "target/classes"]
+ ["src" "resources" "target/classes"]
+
+ :deps/prep-lib
+ {:alias :build
+  :fn compile
+  :ensure "target/classes"}
 
  :deps
  {com.github.jsqlparser/jsqlparser {:mvn/version "4.8"}} ; The actual SQL Parser to wrap!


### PR DESCRIPTION
lets you do the following:

```shell
❯ cat deps.edn
{:deps {mb/macaw {:local/root "/Users/dan/projects/work/macaw"}}}

❯ clj
Error building classpath. The following libs must be prepared before use: [mb/macaw]

❯ clj -X:deps prep
Prepping mb/macaw in /Users/dan/projects/work/macaw
Note: Annotation processing is enabled because one or more processors were found
  on the class path. A future release of javac may disable annotation processing
  unless at least one processor is specified by name (-processor), or a search
  path is specified (--processor-path, --processor-module-path), or annotation
  processing is enabled explicitly (-proc:only, -proc:full).
  Use -Xlint:-options to suppress this message.
  Use -proc:none to disable annotation processing.
Note: ./java/com/metabase/macaw/ASTWalker.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

❯ clj
Clojure 1.11.1
user=> (require 'macaw.core)
nil
user=>
```