### PR TITLE
Don't use schema name

### DIFF
--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -22,7 +22,7 @@
         ast-walker (ASTWalker. {:column (fn [^Column column]
                                           (swap! column-names conj (.getColumnName column)))
                                 :table  (fn [^Table table]
-                                          (swap! table-names conj (.getFullyQualifiedName table)))})]
+                                          (swap! table-names conj (.getName table)))})]
     (.walk ast-walker parsed-query)
     {:columns @column-names
      :tables  @table-names}))

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -12,7 +12,8 @@
     (is (= #{"core_user"}
            (tables "select id, email from core_user;"))))
   (testing "With a schema (Postgres)" ;; TODO: only run this against supported DBs
-    (is (= #{"the_schema_name.core_user"}
+    ;; It strips the schema
+    (is (= #{"core_user"}
            (tables "select * from the_schema_name.core_user;"))))
   (testing "Sub-selects"
     (is (= #{"core_user"}


### PR DESCRIPTION
Reliably determining what the schema name is turns out to be a little complicated what with quoted names including dots and such. Don't use it for now.

c.f. https://github.com/metabase/metabase/issues/39233