### PR TITLE
Fix README command instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This will create a JAR in the `target` directory.
 To compile the Java files, use
 
 ```
-./bin/compile-java
+./bin/java-compile
 ```
 
 If you're working on Macaw and make changes to a Java file, you must:


### PR DESCRIPTION
Verbs postfix in this script name are 🦜 