### PR TITLE
add table and schema information to columns/tables when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.1.29
+
+* Now each component is a map rather than a string, with tables being `{:table "foo" :schema "bar"}` (`:schema` is
+  present only if known) and columns `{:column "foo" :table "bar" :schema "baz"}` (`:table` and `:schema` being
+  optional. So `:columns` will look like that:
+
+```
+#{{:component {:column "foo" :table "bar"} :context ["SELECT"]}}
+```
+
 # 0.1.28
 
 * Context is now added to each returned component in `query->components`. E.g., instead of `#{"foo" "bar"}`, it will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Now each component is a map rather than a string, with tables being `{:table "foo" :schema "bar"}` (`:schema` is
   present only if known) and columns `{:column "foo" :table "bar" :schema "baz"}` (`:table` and `:schema` being
-  optional. So `:columns` will look like that:
+  optional). So `:columns` will look like that:
 
 ```
 #{{:component {:column "foo" :table "bar"} :context ["SELECT"]}}

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -1,6 +1,7 @@
 (ns macaw.core
   (:require
    [macaw.rewrite :as rewrite]
+   [macaw.util :as u]
    [macaw.walk :as mw])
   (:import
    (net.sf.jsqlparser.expression Alias)
@@ -33,19 +34,33 @@
                   :tables            #{}
                   :table-wildcards   #{}}))
 
+(defn- make-table [^Table t]
+  (merge
+    {:table (.getName t)}
+    (when-let [s (.getSchemaName t)]
+      {:schema s})))
+
+(defn- make-column [aliases ^Column c]
+  (merge
+    {:column (.getColumnName c)}
+    (when-let [t (.getTable c)]
+      (or
+        (get aliases (.getName t))
+        (make-table t)))))
+
 (defn- alias-mapping
   [^Table table]
   (when-let [^Alias table-alias (.getAlias table)]
-    [(.getName table-alias) (.getName table)]))
+    [(.getName table-alias) (make-table table)]))
 
 (defn- resolve-table-name
   "JSQLParser can't tell whether the `f` in `select f.*` refers to a real table or an alias. Therefore, we have to
   disambiguate them based on our own map of aliases->table names. So this function will return the real name of the table
   referenced in a table-wildcard (as far as can be determined from the query)."
-  [alias->name ^AllTableColumns atc]
+  [alias->table name->table ^AllTableColumns atc]
   (let [table-name (-> atc .getTable .getName)]
-    (or (alias->name table-name)
-        table-name)))
+    (or (alias->table table-name)
+        (name->table table-name))))
 
 (defn- update-components
   [f components]
@@ -60,12 +75,15 @@
   (let [{:keys [columns has-wildcard?
                 mutation-commands
                 tables table-wildcards]} (query->raw-components parsed-query)
-        aliases                   (into {} (map (comp alias-mapping :component) tables))]
-    {:columns           (into #{} (update-components #(.getColumnName ^Column %) columns))
+        aliases                          (into {} (map #(-> % :component alias-mapping) tables))
+        tables                           (->> (update-components make-table tables)
+                                              (u/group-with #(-> % :component :table)
+                                                            (fn [a b] (if (:schema a) a b))))]
+    {:columns           (into #{} (update-components (partial make-column aliases) columns))
      :has-wildcard?     (into #{} has-wildcard?)
      :mutation-commands (into #{} mutation-commands)
-     :tables            (into #{} (update-components #(.getName ^Table %) tables))
-     :table-wildcards   (into #{} (update-components (partial resolve-table-name aliases) table-wildcards))}))
+     :tables            (into #{} (vals tables))
+     :table-wildcards   (into #{} (update-components (partial resolve-table-name aliases tables) table-wildcards))}))
 
 (defn parsed-query
   "Main entry point: takes a string query and returns a `Statement` object that can be handled by the other functions."

--- a/src/macaw/util.clj
+++ b/src/macaw/util.clj
@@ -1,7 +1,7 @@
 (ns macaw.util)
 
 (defn group-with
-  "Generalized `group-by`, where you can supply your own returning function (instead of usual `conj`).
+  "Generalized `group-by`, where you can supply your own reducing function (instead of usual `conj`).
 
   https://ask.clojure.org/index.php/12319/can-group-by-be-generalized"
   [kf rf coll]

--- a/src/macaw/util.clj
+++ b/src/macaw/util.clj
@@ -1,0 +1,14 @@
+(ns macaw.util)
+
+(defn group-with
+  "Generalized `group-by`, where you can supply your own returning function (instead of usual `conj`).
+
+  https://ask.clojure.org/index.php/12319/can-group-by-be-generalized"
+  [kf rf coll]
+  (persistent!
+    (reduce
+      (fn [ret x]
+        (let [k (kf x)]
+          (assoc! ret k (rf (get ret k) x))))
+      (transient {})
+      coll)))


### PR DESCRIPTION
That way we could match them to known fields in a less ambiguous way.