### PR TITLE
Add query context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.27
+# 0.1.28
 
 * Context is now added to each returned component in `query->components`. E.g., instead of `#{"foo" "bar"}`, it will
   return its elements as `#{{:component "foo" :context ["SELECT"]}, {:component "bar" :context ["WHERE" "SELECT"]}}`
@@ -19,6 +19,6 @@
   least-specific. For most cases you probably only want to look at the first element and/or make assertions about the
   relative order of multiple elements.
 
-# 0.0.1 through 0.1.26
+# 0.0.1 through 0.1.27
 
 * (The project was young enough not to merit a changelog. Refer to other documentation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# 0.1.27
+
+* Context is now added to each returned component in `query->components`. E.g., instead of `#{"foo" "bar"}`, it will
+  return its elements as `#{{:component "foo" :context ["SELECT"]}, {:component "bar" :context ["WHERE" "SELECT"]}}`
+
+* `has-wildcard` now returns a set of such maps. For example:
+
+```
+(query->components (parsed-query "SELECT * FROM (SELECT * FROM orders) WHERE total > 10"))
+; =>
+{ ...
+  :has-wildcard?
+  #{{:component true, :context ["SELECT" "SUB_SELECT" "FROM" "SELECT"]}
+    {:component true, :context ["SELECT"]}}}
+```
+
+* The context stack can be counter-intuitive. For example, in the above query, the context stack for the `"total"`
+  column from the `WHERE` clauses is `["WHERE" "JOIN" "FROM" "SELECT"]`. The vector is arranged from most- to
+  least-specific. For most cases you probably only want to look at the first element and/or make assertions about the
+  relative order of multiple elements.
+
+# 0.0.1 through 0.1.26
+
+* (The project was young enough not to merit a changelog. Refer to other documentation)

--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -52,7 +52,7 @@
   "Emit a SQL string for an updated AST, preserving the comments and whitespace from the original SQL."
   [updated-ast sql]
   (let [replace-name (fn [->s]
-                       (fn [acc ^ASTNodeAccess visitable]
+                       (fn [acc ^ASTNodeAccess visitable _ctx]
                          (let [node (.getASTNode visitable)]
                            ;; not sure why sometimes we get a phantom visitable without an underlying node
                            (if (nil? node)
@@ -67,7 +67,7 @@
       []))))
 
 (defn- rename-table
-  [table-renames ^Table table]
+  [table-renames ^Table table _ctx]
   (when-let [name' (get table-renames (.getName table))]
     (.setName table name')))
 
@@ -78,6 +78,6 @@
       (mw/walk-query
        {:table            (partial rename-table table-renames)
         :column-qualifier (partial rename-table table-renames)
-        :column           (fn [^Column column] (when-let [name' (get column-renames (.getColumnName column))]
-                                                 (.setColumnName column name')))})
+        :column           (fn [^Column column _ctx] (when-let [name' (get column-renames (.getColumnName column))]
+                                                      (.setColumnName column name')))})
       (update-query sql)))

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -23,7 +23,7 @@
 (defn column-qualifiers
   [query]
   (mw/fold-query (m/parsed-query query)
-                 {:column-qualifier #(conj %1 (.getName ^Table %2))}
+                 {:column-qualifier (fn [acc tbl _ctx] (conj acc (.getName ^Table tbl)))}
                  #{}))
 
 (deftest query->tables-test

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -8,12 +8,17 @@
 
 (set! *warn-on-reflection* true)
 
-(def components    (comp m/query->components m/parsed-query))
-(def columns       (comp :columns components))
-(def has-wildcard? (comp :has-wildcard? components))
-(def mutations     (comp :mutation-commands components))
-(def tables        (comp :tables components))
-(def table-wcs     (comp :table-wildcards components))
+(defn- and*
+  [x y]
+  (and x y))
+
+(def components     (comp m/query->components m/parsed-query))
+(def raw-components (comp (partial into #{}) (partial map :component)))
+(def columns        (comp raw-components :columns components))
+(def has-wildcard?  (comp (partial reduce and*) raw-components :has-wildcard? components))
+(def mutations      (comp raw-components :mutation-commands components))
+(def tables         (comp raw-components :tables components))
+(def table-wcs      (comp raw-components :table-wildcards components))
 
 (defn column-qualifiers
   [query]
@@ -155,6 +160,45 @@
          (table-wcs "SELECT o.* FROM orders o JOIN foo ON orders.id = foo.order_id")))
     (is (= #{"foo"}
          (table-wcs "SELECT f.* FROM orders o JOIN foo f ON orders.id = foo.order_id"))))
+
+(deftest context-test
+  (testing "Sub-select with outer wildcard"
+    (is (= {:columns
+            #{{:component "total", :context ["SELECT" "SUB_SELECT" "FROM" "SELECT"]}
+              {:component "id",    :context ["SELECT" "SUB_SELECT" "FROM" "SELECT"]}
+              {:component "total", :context ["WHERE" "JOIN" "FROM" "SELECT"]}},
+            :has-wildcard?     #{{:component true, :context ["SELECT"]}},
+            :mutation-commands #{},
+            :tables            #{{:component "orders", :context ["FROM" "SELECT" "SUB_SELECT" "FROM" "SELECT"]}},
+            :table-wildcards   #{}}
+           (components "SELECT * FROM (SELECT id, total FROM orders) WHERE total > 10"))))
+  (testing "Sub-select with inner wildcard"
+    (is (= {:columns
+            #{{:component "id",    :context ["SELECT"]}
+              {:component "total", :context ["SELECT"]}
+              {:component "total", :context ["WHERE" "JOIN" "FROM" "SELECT"]}},
+            :has-wildcard?     #{{:component true, :context ["SELECT" "SUB_SELECT" "FROM" "SELECT"]}},
+            :mutation-commands #{},
+            :tables            #{{:component "orders", :context ["FROM" "SELECT" "SUB_SELECT" "FROM" "SELECT"]}},
+            :table-wildcards   #{}}
+           (components "SELECT id, total FROM (SELECT * FROM orders) WHERE total > 10"))))
+  (testing "Sub-select with dual wildcards"
+    (is (= {:columns           #{{:component "total", :context ["WHERE" "JOIN" "FROM" "SELECT"]}},
+            :has-wildcard?
+            #{{:component true, :context ["SELECT" "SUB_SELECT" "FROM" "SELECT"]}
+              {:component true, :context ["SELECT"]}},
+            :mutation-commands #{},
+            :tables            #{{:component "orders", :context ["FROM" "SELECT" "SUB_SELECT" "FROM" "SELECT"]}},
+            :table-wildcards   #{}}
+           (components "SELECT * FROM (SELECT * FROM orders) WHERE total > 10"))))
+  (testing "Join; table wildcard"
+    (is (= {:columns           #{{:component "order_id", :context ["JOIN" "SELECT"]}
+                                 {:component "id", :context ["JOIN" "SELECT"]}},
+            :has-wildcard?     #{},
+            :mutation-commands #{},
+            :tables            #{{:component "foo", :context ["FROM" "JOIN" "SELECT"]} {:component "orders", :context ["FROM" "SELECT"]}},
+            :table-wildcards   #{{:component "orders", :context ["SELECT"]}}}
+         (components "SELECT o.* FROM orders o JOIN foo ON orders.id = foo.order_id")))))
 
 (defn test-replacement [before replacements after]
   (is (= after (m/replace-names before replacements))))


### PR DESCRIPTION
Noisy diff since everything is a `{:component original-thing, :context [...]}` now, but I think the actual semantics of the changes are pretty straighforward.

JSqlParser is inventing some phantom elements (especially JOINs) and I decided it was better to just roll with it for now and let the clients deal with it. Better to have too much info than not enough.

Things were getting hairy so I added a CHANGELOG. Keeping the version numbers correct is a bit of a pain (if a PR merges before this one I'll have to increment the version)