### PR TITLE
determine column alias

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,8 +1,10 @@
 ((nil . ((indent-tabs-mode . nil)       ; always use spaces for tabs
          (require-final-newline . t)))  ; add final newline on save
+ (java-mode . ((whitespace-line-column . 118)))
  (clojure-mode . ((cider-preferred-build-tool . clojure-cli)
                   (cider-clojure-cli-aliases . "dev:user")
                   (cljr-favor-prefix-notation . nil)
+                  (cljr-insert-newline-after-require . t)
                   ;; prefer keeping source width about ~118, GitHub seems to cut
                   ;; off stuff at either 119 or 120 and it's nicer to look at
                   ;; code in GH when you don't have to scroll back and forth

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -12,6 +12,7 @@
                   (whitespace-line-column . 118)
                   (column-enforce-column . 118)
                   (clojure-docstring-fill-column . 118)
+                  (clojure-indent-style . always-align)
                   (eval . (put-clojure-indent 'with-meta '(:form)))
                   (eval . (put-clojure-indent 'with-bindings* '(:form)))))
  (markdown-mode . ((fill-column . 80)

--- a/java/com/metabase/macaw/AstWalker.java
+++ b/java/com/metabase/macaw/AstWalker.java
@@ -281,6 +281,10 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
         this.contextStack.push(c.toString());
     }
 
+    private void pushContext(String s) {
+        this.contextStack.push(s);
+    }
+
     // This is pure sugar, but it's nice to be symmetrical with pushContext
     private void popContext() {
         this.contextStack.pop();
@@ -838,7 +842,16 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
 
     @Override
     public void visit(SelectItem item) {
+        // TODO: what are .getAliasColumns()? Should we look at them?
+        var alias = item.getAlias();
+        if (alias != null) {
+            // FIXME: this is absolutely a hack, what's the best way to get around it?
+            pushContext("AS " + alias.getName());
+        }
         item.getExpression().accept(this);
+        if (alias != null) {
+            popContext();
+        }
     }
 
     @Override

--- a/java/com/metabase/macaw/AstWalker.java
+++ b/java/com/metabase/macaw/AstWalker.java
@@ -228,7 +228,12 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
         }
     }
 
-    public enum QueryContext {
+    public interface QueueItem {
+        public String getKey();
+        public String getValue();
+    }
+
+    public enum QueryContext implements QueueItem {
         DELETE,
         ELSE,
         FROM,
@@ -242,8 +247,30 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
         UPDATE,
         WHERE;
 
-        public String toString() {
+        public String getKey() {
+            return "query";
+        }
+
+        public String getValue() {
             return name().toUpperCase();
+        }
+    }
+
+    public class SomeContext implements QueueItem {
+        private String key;
+        private String value;
+
+        SomeContext(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public String getKey() {
+            return this.key;
+        }
+
+        public String getValue() {
+            return this.value;
         }
     }
 
@@ -251,7 +278,7 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
 
     private Acc acc;
     private final EnumMap<CallbackKey, IFn> callbacks;
-    private final Deque<String> contextStack;
+    private final Deque<QueueItem> contextStack;
 
     /**
      * Construct a new walker with the given `callbacks`. The `callbacks` should be a (Clojure) map of CallbackKeys to
@@ -262,7 +289,7 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
     public AstWalker(Map<CallbackKey, IFn> rawCallbacks, Acc val) {
         this.acc = val;
         this.callbacks = new EnumMap<>(rawCallbacks);
-        this.contextStack = new ArrayDeque<String>();
+        this.contextStack = new ArrayDeque<QueueItem>();
     }
 
     /**
@@ -278,11 +305,11 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
     }
 
     private void pushContext(QueryContext c) {
-        this.contextStack.push(c.toString());
+        this.contextStack.push(c);
     }
 
-    private void pushContext(String s) {
-        this.contextStack.push(s);
+    private void pushContext(QueueItem item) {
+        this.contextStack.push(item);
     }
 
     // This is pure sugar, but it's nice to be symmetrical with pushContext
@@ -846,7 +873,7 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
         var alias = item.getAlias();
         if (alias != null) {
             // FIXME: this is absolutely a hack, what's the best way to get around it?
-            pushContext("AS " + alias.getName());
+            pushContext(new SomeContext("alias", alias.getName()));
         }
         item.getExpression().accept(this);
         if (alias != null) {

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -1,5 +1,6 @@
 (ns macaw.core
   (:require
+   [clojure.string :as str]
    [macaw.rewrite :as rewrite]
    [macaw.util :as u]
    [macaw.walk :as mw])
@@ -34,40 +35,54 @@
                   :tables            #{}
                   :table-wildcards   #{}}))
 
-(defn- make-table [^Table t]
+;;; tables
+
+(defn- make-table [^Table t _ctx]
   (merge
     {:table (.getName t)}
     (when-let [s (.getSchemaName t)]
       {:schema s})))
 
-(defn- make-column [alias-map table-map ^Column c]
-  (merge
-    {:column (.getColumnName c)}
-    (if-let [t (.getTable c)]
-      (or
-        (get alias-map (.getName t))
-        (:component (get table-map (.getName t))))
-      ;; if we see only a single table, we can safely say it's the table of that column
-      (when (= (count table-map) 1)
-        (:component (val (first table-map)))))))
-
 (defn- alias-mapping
-  [^Table table]
+  [^Table table ctx]
   (when-let [^Alias table-alias (.getAlias table)]
-    [(.getName table-alias) (make-table table)]))
+    [(.getName table-alias) (make-table table ctx)]))
 
 (defn- resolve-table-name
   "JSQLParser can't tell whether the `f` in `select f.*` refers to a real table or an alias. Therefore, we have to
   disambiguate them based on our own map of aliases->table names. So this function will return the real name of the table
   referenced in a table-wildcard (as far as can be determined from the query)."
-  [alias->table name->table ^AllTableColumns atc]
+  [{:keys [alias->table name->table]} ^AllTableColumns atc _ctx]
   (let [table-name (-> atc .getTable .getName)]
     (or (alias->table table-name)
         (name->table table-name))))
 
+;;; columns
+
+(defn- maybe-column-alias [ctx]
+  (when (some-> (first ctx) (str/starts-with? "AS "))
+    {:alias (subs (first ctx) 3)}))
+
+(defn- maybe-column-table [{:keys [alias->table name->table]} ^Column c]
+  (if-let [t (.getTable c)]
+    (or
+      (get alias->table (.getName t))
+      (:component (get name->table (.getName t))))
+    ;; if we see only a single table, we can safely say it's the table of that column
+    (when (= (count name->table) 1)
+      (:component (val (first name->table))))))
+
+(defn- make-column [data ^Column c ctx]
+  (merge
+    {:column (.getColumnName c)}
+    (maybe-column-alias ctx)
+    (maybe-column-table data c)))
+
+;;; get them together
+
 (defn- update-components
   [f components]
-  (map #(update % :component f) components))
+  (map #(update % :component f (:context %)) components))
 
 (defn query->components
   "Given a parsed query (i.e., a [subclass of] `Statement`) return a map with the elements found within it.
@@ -75,18 +90,22 @@
   (Specifically, it returns their fully-qualified names as strings, where 'fully-qualified' means 'as referred to in
   the query'; this function doesn't do additional inference work to find out a table's schema.)"
   [^Statement parsed-query]
-  (let [{:keys [columns has-wildcard?
+  (let [{:keys [columns
+                has-wildcard?
                 mutation-commands
-                tables table-wildcards]} (query->raw-components parsed-query)
-        alias-map                        (into {} (map #(-> % :component alias-mapping) tables))
-        table-map                        (->> (update-components make-table tables)
-                                                 (u/group-with #(-> % :component :table)
-                                                   (fn [a b] (if (:schema a) a b))))]
-    {:columns           (into #{} (update-components (partial make-column alias-map table-map) columns))
+                tables
+                table-wildcards]} (query->raw-components parsed-query)
+        alias-map                 (into {} (map #(-> % :component (alias-mapping (:context %))) tables))
+        table-map                 (->> (update-components make-table tables)
+                                              (u/group-with #(-> % :component :table)
+                                                (fn [a b] (if (:schema a) a b))))
+        data                      {:alias->table alias-map
+                                   :name->table  table-map}]
+    {:columns           (into #{} (update-components (partial make-column data) columns))
      :has-wildcard?     (into #{} has-wildcard?)
      :mutation-commands (into #{} mutation-commands)
      :tables            (into #{} (vals table-map))
-     :table-wildcards   (into #{} (update-components (partial resolve-table-name alias-map table-map) table-wildcards))}))
+     :table-wildcards   (into #{} (update-components (partial resolve-table-name data) table-wildcards))}))
 
 (defn parsed-query
   "Main entry point: takes a string query and returns a `Statement` object that can be handled by the other functions."

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -76,6 +76,15 @@
     (is (= #{{:column "id" :table "orders" :schema "public"}}
            (columns "SELECT o.id FROM public.orders o")))))
 
+(deftest infer-test
+  (testing "We can first column through a few hoops"
+    (is (= #{{:column "amount" :table "orders"}}
+           (columns "SELECT amount FROM (SELECT amount FROM orders)")))
+    (is (= #{{:column "amount" :alias "cost" :table "orders"}
+             ;; FIXME: we need to figure out that `cost` is an alias from subquery
+             {:column "cost", :table "orders"}}
+           (columns "SELECT cost FROM (SELECT amount AS cost FROM orders)")))))
+
 (deftest mutation-test
   (is (= #{"alter-sequence"}
          (mutations "ALTER SEQUENCE serial RESTART WITH 42")))


### PR DESCRIPTION
This code will determine column alias. I haven't found a better idea than hijacking context, but at least it's not string manipulation (see first commit).

I don't have any good ideas on how to propagate knowledge from subqueries to external (to them) aliases (which we currently determine as columns), maybe we need/want to try and figure out connection between columns and subqueries? Maybe we want to improve context in a way where we could say "those two are under the same context"? This probably requires some id for the context items.