### PR TITLE
Allow unused renames if flag provided

### DIFF
--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -117,5 +117,6 @@
                              :column-qualifier (partial rename-table updated-nodes table-renames schema-renames tables)
                              :column           (partial rename-column updated-nodes column-renames columns)})
                            (update-query @updated-nodes sql opts))]
-    (alert-unused! @updated-nodes renames)
+    (when-not (:allow-unused? opts)
+      (alert-unused! @updated-nodes renames))
     res))

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -259,10 +259,7 @@
                        {:schema "public" :table "bore_user"}  "user"
                        {:schema "public" :table "snore_user"} "vigilant_user"}
              :columns {{:schema "public" :table "core_user" :column "boink"}  "sturmunddrang"
-                       {:schema "public" :table "snore_user" :column "yoink"} "oink"}})))
-
-  (is (thrown? Exception #"Unknown rename"
-               (m/replace-names "SELECT 1" {:tables {{:schema "public" :table "a"} "aa"}}))))
+                       {:schema "public" :table "snore_user" :column "yoink"} "oink"}}))))
 
 (deftest case-insensitive-test
   ;; In future we might try to be smarter and preserve case.
@@ -278,3 +275,11 @@
                           {:schemas {"public" "totally_private"}
                            :tables  {{:schema "public" :table "orders"} "purchases"}
                            :columns {{:schema "public" :table "orders" :column "x"} "xx"}}))))
+
+(deftest allow-unused-test
+  (is (thrown-with-msg?
+       Exception #"Unknown rename"
+       (m/replace-names "SELECT 1" {:tables {{:schema "public" :table "a"} "aa"}})))
+  (is (= "SELECT 1"
+         (m/replace-names "SELECT 1" {:tables {{:schema "public" :table "a"} "aa"}}
+                          {:allow-unused? true}))))


### PR DESCRIPTION
It turns out that a few of our metabase tests depend on certain replacements being ignored, so this adds an option to suppress the validation that each source reference is found at least once.

Since this is not a particularly user friendly error, I think it makes sense to pass this flag by default from Metabase. 

Perhaps it should even be the default behavior and Macaw should require an opt-in for the validation. I've left it for now since ergonomically it's nice for all our unit tests to be exhaustive, without a wrapper to set the flag.