### PR TITLE
Fix replacement of columns in queries that reference a single model

### DIFF
--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -17,8 +17,8 @@
 
   (Specifically, it returns their fully-qualified names as strings, where 'fully-qualified' means 'as referred to in
   the query'; this function doesn't do additional inference work to find out a table's schema.)"
-  [statement]
-  (collect/query->components statement))
+  [statement & {:as opts}]
+  (collect/query->components statement opts))
 
 (defn replace-names
   "Given a SQL query, apply the given table, column, and schema renames."

--- a/src/macaw/util.clj
+++ b/src/macaw/util.clj
@@ -1,4 +1,6 @@
-(ns macaw.util)
+(ns macaw.util
+  (:require
+   [clojure.string :as str]))
 
 (defn group-with
   "Generalized `group-by`, where you can supply your own reducing function (instead of usual `conj`).
@@ -22,13 +24,19 @@
    nil
    coll))
 
+(defn non-sentinel
+  "A hack around the fact that we don't (yet) track what columns are exposed by given sentinels."
+  [s]
+  (when s
+    (nil? (str/index-of s "_sentinel_"))))
+
 (defn find-relevant
   "Search the given map for the entry corresponding to [[map-key]], considering only the relevant keys.
   The relevant keys are obtained by ignoring any suffix of [[ks]] for which [[map-key]] has nil or missing values.
   We require that there is at least one relevant key to find a match."
   [m map-key ks]
   (when map-key
-    (if (every? map-key ks)
+    (if (every? (comp non-sentinel map-key) ks)
       (find m (select-keys map-key ks))
       ;; Strip off keys from right-to-left where they are nil, and relax search to only consider these keys.
       ;; We need at least one non-generate key to remain for the search.

--- a/src/macaw/util.clj
+++ b/src/macaw/util.clj
@@ -40,6 +40,7 @@
       (find m (select-keys map-key ks))
       ;; Strip off keys from right-to-left where they are nil, and relax search to only consider these keys.
       ;; We need at least one non-generate key to remain for the search.
+      ;; NOTE: we could optimize away calling `non-sentinel` twice in this function, but for now just keeping it simple.
       (when-let [ks-prefix (->> ks reverse (drop-while (comp not non-sentinel map-key)) reverse seq)]
         (when (not= ks ks-prefix)
           (seek (comp #{(select-keys map-key ks-prefix)}

--- a/src/macaw/util.clj
+++ b/src/macaw/util.clj
@@ -40,7 +40,7 @@
       (find m (select-keys map-key ks))
       ;; Strip off keys from right-to-left where they are nil, and relax search to only consider these keys.
       ;; We need at least one non-generate key to remain for the search.
-      (when-let [ks-prefix (->> ks reverse (drop-while (comp nil? map-key)) reverse seq)]
+      (when-let [ks-prefix (->> ks reverse (drop-while (comp not non-sentinel map-key)) reverse seq)]
         (when (not= ks ks-prefix)
           (seek (comp #{(select-keys map-key ks-prefix)}
                       #(select-keys % ks-prefix)

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -344,7 +344,7 @@
                           {:allow-unused? true}))))
 
 (deftest model-reference-test
-  (m/replace-names "SELECT total FROM metabase_sentinel_table_154643 LIMIT 3"
+  (m/replace-names "SELECT subtotal FROM metabase_sentinel_table_154643 LIMIT 3"
                    {:columns {{:table "orders" :column "total"} "subtotal"}
                     :tables  {{:table "orders"} "purchases"}}
                    {:allow-unused? true}))

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -342,3 +342,9 @@
   (is (= "SELECT 1"
          (m/replace-names "SELECT 1" {:tables {{:schema "public" :table "a"} "aa"}}
                           {:allow-unused? true}))))
+
+(deftest model-reference-test
+  (m/replace-names "SELECT total FROM metabase_sentinel_table_154643 LIMIT 3"
+                   {:columns {{:table "orders" :column "total"} "subtotal"}
+                    :tables  {{:table "orders"} "purchases"}}
+                   {:allow-unused? true}))

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -344,7 +344,8 @@
                           {:allow-unused? true}))))
 
 (deftest model-reference-test
-  (m/replace-names "SELECT subtotal FROM metabase_sentinel_table_154643 LIMIT 3"
-                   {:columns {{:table "orders" :column "total"} "subtotal"}
-                    :tables  {{:table "orders"} "purchases"}}
-                   {:allow-unused? true}))
+  (is (= "SELECT subtotal FROM  metabase_sentinel_table_154643 LIMIT 3")
+      (m/replace-names "SELECT total FROM metabase_sentinel_table_154643 LIMIT 3"
+                       {:columns {{:table "orders" :column "total"} "subtotal"}
+                        :tables  {{:table "orders"} "purchases"}}
+                       {:allow-unused? true})))

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -344,8 +344,8 @@
                           {:allow-unused? true}))))
 
 (deftest model-reference-test
-  (is (= "SELECT subtotal FROM  metabase_sentinel_table_154643 LIMIT 3")
-      (m/replace-names "SELECT total FROM metabase_sentinel_table_154643 LIMIT 3"
-                       {:columns {{:table "orders" :column "total"} "subtotal"}
-                        :tables  {{:table "orders"} "purchases"}}
-                       {:allow-unused? true})))
+  (is (= "SELECT subtotal FROM metabase_sentinel_table_154643 LIMIT 3"
+         (m/replace-names "SELECT total FROM metabase_sentinel_table_154643 LIMIT 3"
+                          {:columns {{:table "orders" :column "total"} "subtotal"}
+                           :tables  {{:table "orders"} "purchases"}}
+                          {:allow-unused? true}))))


### PR DESCRIPTION
We had a small regression here when moving to use qualifiers, which could result in renames not propagating to questions which reference other cards.

Example:

```sql
SELECT total FROM metabase_sentinel_table_154643 LIMIT 3
```

Because there is only a single "table" here, we will resolve the "naked" column reference to:

```clojure
{:table "metabase_sentinel_table_154643", :column "total"}
```

Then, because `:table` is not nil, we will not "cascade" when looking in the replace map, and it will not find the underlying `{:table "orders", :column "total"}` entry.

This PR makes it so that any sentinel values are ignored when deciding how to do the search.