### PR TITLE
Preserve case and quotes when describing identifiers

### DIFF
--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -53,15 +53,17 @@
 
 (defn normalize-reference
   "Normalize a schema, table, column, etc. references so that we can match them regardless of syntactic differences."
-  [s {:keys [case-insensitive? quotes-preserve-case?]}]
-  (when s
-    (let [quoted (quoted? s)
-          case-insensitive (and case-insensitive?
-                                (not (and quotes-preserve-case?
-                                          quoted)))]
-      (cond-> s
-        quoted           strip-quotes
-        case-insensitive str/lower-case))))
+  [s {:keys [preserve-identifiers? case-insensitive? quotes-preserve-case?]}]
+  (if preserve-identifiers?
+    s
+    (when s
+      (let [quoted           (quoted? s)
+            case-insensitive (and case-insensitive?
+                                  (not (and quotes-preserve-case?
+                                            quoted)))]
+        (cond-> s
+          quoted strip-quotes
+          case-insensitive str/lower-case)))))
 
 (defn- find-table [{:keys [alias->table name->table] :as opts} ^Table t]
   (let [n      (normalize-reference (.getName t) opts)
@@ -137,7 +139,7 @@
 
 (defn query->components
   "See macaw.core/query->components doc."
-  [^Statement parsed-ast & [opts]]
+  [^Statement parsed-ast & {:as opts}]
   (let [{:keys [columns
                 qualifiers
                 has-wildcard?

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -18,7 +18,9 @@
   (Specifically, it returns their fully-qualified names as strings, where 'fully-qualified' means 'as referred to in
   the query'; this function doesn't do additional inference work to find out a table's schema.)"
   [statement & {:as opts}]
-  (collect/query->components statement opts))
+  ;; By default, we will preserve identifiers verbatim, to be agnostic of case and quote behaviour.
+  ;; This may result in duplicate components, which are left to the caller to deduplicate.
+  (collect/query->components statement (merge {:preserve-identifiers? true} opts)))
 
 (defn replace-names
   "Given a SQL query, apply the given table, column, and schema renames."


### PR DESCRIPTION
It turns out that we can make our lives much easier for Metabase by just opting out of identifier normalization when describing fields, as the test suite is currently relying on the identifiers being normalized and deduplicated implicitly when selecting the fields.

This "agnostic mode" seems like a good default.