### PR TITLE
Support more twists and turns around case insensitivity

### DIFF
--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -52,10 +52,9 @@
 (defn- strip-quotes [s]
   (subs s 1 (dec (count s))))
 
-(defn- setting->relax-case [setting]
-  (when setting
-    (case setting
-      true str/lower-case
+(defn- setting->relax-case [{:keys [case-insensitive]}]
+  (when case-insensitive
+    (case case-insensitive
       :lower str/lower-case
       :upper str/upper-case
       ;; This will work for replace, but not for analyzing where we need a literal to accumulate
@@ -63,13 +62,13 @@
 
 (defn normalize-reference
   "Normalize a schema, table, column, etc. references so that we can match them regardless of syntactic differences."
-  [s {:keys [preserve-identifiers? case-insensitive? quotes-preserve-case?]}]
+  [s {:keys [preserve-identifiers? quotes-preserve-case?] :as opts}]
   (if preserve-identifiers?
     s
     (when s
       (let [quoted     (quoted? s)
             relax-case (when-not (and quotes-preserve-case? quoted)
-                         (setting->relax-case case-insensitive?))]
+                         (setting->relax-case opts))]
         (cond-> s
           quoted     strip-quotes
           relax-case relax-case)))))

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -17,12 +17,25 @@
 
   (Specifically, it returns their fully-qualified names as strings, where 'fully-qualified' means 'as referred to in
   the query'; this function doesn't do additional inference work to find out a table's schema.)"
-  [statement & {:as opts}]
+  [statement & {:as _opts}]
   ;; By default, we will preserve identifiers verbatim, to be agnostic of case and quote behaviour.
   ;; This may result in duplicate components, which are left to the caller to deduplicate.
-  (collect/query->components statement (merge {:preserve-identifiers? true} opts)))
+  ;; In Metabase's case this is done during the stage where the database metadata is queried.
+  (collect/query->components statement {:preserve-identifiers? true}))
 
 (defn replace-names
-  "Given a SQL query, apply the given table, column, and schema renames."
+  "Given a SQL query, apply the given table, column, and schema renames.
+
+  Supported options:
+
+  - case-insensitive: whether to relax the comparison
+    - :upper    - identifiers are implicitly case to uppercase, as per the SQL-92 standard.
+    - :lower    - identifiers are implicitly cast to lowercase, as per Postgres et al.
+    - :agnostic - case is ignored when comparing identifiers in code to replacement \"from\" strings.
+
+  - quotes-preserve-case: whether quoted identifiers should override the previous option."
   [sql renames & {:as opts}]
-  (rewrite/replace-names sql (parsed-query sql) renames opts))
+  (rewrite/replace-names sql
+                         (parsed-query sql)
+                         renames
+                         (select-keys opts [:case-insensitive :quotes-preserve-case?])))

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -17,11 +17,11 @@
 
   (Specifically, it returns their fully-qualified names as strings, where 'fully-qualified' means 'as referred to in
   the query'; this function doesn't do additional inference work to find out a table's schema.)"
-  [statement & {:as _opts}]
+  [statement & {:as opts}]
   ;; By default, we will preserve identifiers verbatim, to be agnostic of case and quote behaviour.
   ;; This may result in duplicate components, which are left to the caller to deduplicate.
   ;; In Metabase's case this is done during the stage where the database metadata is queried.
-  (collect/query->components statement {:preserve-identifiers? true}))
+  (collect/query->components statement (merge {:preserve-identifiers? true} opts)))
 
 (defn replace-names
   "Given a SQL query, apply the given table, column, and schema renames.
@@ -38,4 +38,4 @@
   (rewrite/replace-names sql
                          (parsed-query sql)
                          renames
-                         (select-keys opts [:case-insensitive :quotes-preserve-case?])))
+                         (select-keys opts [:case-insensitive :quotes-preserve-case? :allow-unused?])))

--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -79,7 +79,7 @@
     (.setName t (val rename)))
   (let [raw-schema-name (.getSchemaName t)
         schema-name     (collect/normalize-reference raw-schema-name opts)]
-    (when-let [schema-rename (find schema-renames schema-name)]
+    (when-let [schema-rename (u/seek (comp (partial u/match-component schema-name) key) schema-renames)]
       (vswap! updated-nodes conj [raw-schema-name schema-rename])
       (.setSchemaName t (val schema-rename)))))
 

--- a/src/macaw/util.clj
+++ b/src/macaw/util.clj
@@ -1,6 +1,7 @@
 (ns macaw.util
   (:require
-   [clojure.string :as str]))
+   [clojure.string :as str])
+  (:import (java.util.regex Pattern)))
 
 (defn group-with
   "Generalized `group-by`, where you can supply your own reducing function (instead of usual `conj`).
@@ -34,9 +35,9 @@
   "Check whether the given literal matches the expected literal or pattern."
   [expected actual]
   (when expected
-    (if (string? expected)
-      (= expected actual)
-      (boolean (re-find expected actual)))))
+    (if (instance? Pattern expected)
+      (boolean (re-find expected actual))
+      (= expected actual))))
 
 (defn- match-prefix [element ks-prefix]
   (let [expected (map element ks-prefix)]

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -10,13 +10,6 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- warnf
-  "Print a warning even from a passing test."
-  [s & args]
-  ^:clj-kondo/ignore
-  (println "WARN:" (apply format s args))
-  (flush))
-
 (defn- and*
   [x y]
   (and x y))


### PR DESCRIPTION
### Description

It turned out that case is handled in more subtly different ways by different engines, and the existing options are not complete enough. Currently Macaw supports Postgres semantics, which turn out to be in the minority.

In order to support more dialects correctly, we now support a few different values of `:case-insensitive?`

- `:upper` - Unquoted identifiers coerce to uppercase. Consistent with SQL-92. Examples: Oracle, Snowflake, H2
- `:lower` - Unquoted identifiers coerce to lowercase. Examples: Postgres, Redshift
- `:agnostic` - Completely ignore case. Examples: MySQL, SQLite

Given how fringe cases where these differences matter, I think it'll be sensible to use `:agnostic` for all replacement in Metabase for now. This way we are not sensitive to any quirks in how we infer the case of fields during sync.

#### Limitations:

- `:agnostic` will not work with analysis, only replacement. ~~(TODO: add `should=` tests around this.)~~
  - We don't care about this, as Metabase skips case normalization during Macaw analysis, and handles it in the queries for the corresponding `Field` instances.

Unfortunately a bunch of small performance enhancements were killed in the name of simplifying this relaxed implementation. "One day, with business reasons and benchmarks, we will come back to this," I tell myself.

#### TODOs:

- [x] More tests
- [x] ~~Make CI fail if `should=` received "correct" answers~~ Leaving macro for another day.
- [x] Deprecate `:case-insensitive?` and use `:case-insensitive` instead. *Just made it a breaking change.*