### PR TITLE
Track unique ids for each scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ $ grep MUTATION_COMMAND java/com/metabase/macaw/AstWalker.java | grep -oEi '".+"
 
 As can be seen above, every item additional has a `:context` key containing a stack (most-specific first) of the query
 components in which the item was found. The definitive list of components if found in
-`com.metabase.macaw.AstWalker.QueryContext`, but as of 0.1.30 the list is as follows (and is unlikely to change):
+`com.metabase.macaw.AstWalker.QueryScopeLabel`, but as of 0.1.30 the list is as follows (and is unlikely to change):
 
 ```java
 DELETE,

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
  :aliases
  {:dev
   {:extra-deps
-   {io.github.metabase/hawk     {:sha "539eefaa31a43d52d7c9b5731f471bb6742e7131"}
+   {io.github.metabase/hawk     {:sha "ac3c663b22114d99303b8da88d982248da391780"}
     virgil/virgil               {:mvn/version "0.3.0"}
     org.clojure/tools.namespace {:mvn/version "1.4.5"}}
 

--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -4,7 +4,7 @@
    [macaw.util :as u]
    [macaw.walk :as mw])
   (:import
-   (com.metabase.macaw AstWalker$QueueItem)
+   (com.metabase.macaw AstWalker$Scope)
    (java.util.regex Pattern)
    (net.sf.jsqlparser.expression Alias)
    (net.sf.jsqlparser.schema Column Table)
@@ -20,8 +20,8 @@
    (fn item-conjer [results component context]
      (update results key-name conj {:component (xf component)
                                     :context   (mapv
-                                                 (fn [^AstWalker$QueueItem x]
-                                                   [(keyword (.getKey x)) (.getValue x)])
+                                                 (fn [^AstWalker$Scope x]
+                                                   [(keyword (.getType x)) (.getLabel x) (.getId x)])
                                                  context)}))))
 
 (defn- query->raw-components
@@ -128,7 +128,7 @@
 
 (defn- only-query-context [ctx]
   (into [] (comp (filter #(= (first %) :query))
-                 (map second))
+                 (map (comp vec rest)))
     ctx))
 
 (defn- update-components

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -18,13 +18,13 @@
   (Specifically, it returns their fully-qualified names as strings, where 'fully-qualified' means 'as referred to in
   the query'; this function doesn't do additional inference work to find out a table's schema.)"
   [statement & {:as opts}]
-  ;; By default, we will preserve identifiers verbatim, to be agnostic of case and quote behaviour.
+  ;; By default, we will preserve identifiers verbatim, to be agnostic of case and quote behavior.
   ;; This may result in duplicate components, which are left to the caller to deduplicate.
-  ;; In Metabase's case this is done during the stage where the database metadata is queried.
+  ;; In Metabase's case, this is done during the stage where the database metadata is queried.
   (collect/query->components statement (merge {:preserve-identifiers? true} opts)))
 
 (defn replace-names
-  "Given a SQL query, apply the given table, column, and schema renames.
+  "Given an SQL query, apply the given table, column, and schema renames.
 
   Supported options:
 

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -510,6 +510,8 @@
 
 (deftest duplicate-scopes-test
   ;; TODO Fix these entries to mention "a" as their source table, otherwise we cannot compute the source fields.
+  ;; TODO Fix kondo linting of =?/same
+  #_{:clj-kondo/ignore [:unresolved-symbol]}
   (is (=? [{:component {:column "x"}, :scope ["SELECT" (=?/same :subselect-1)]}
            {:component {:column "x"}, :scope ["SELECT" (=?/same :subselect-2)]}
            {:component {:table "b", :column "x"}, :scope ["SUB_SELECT" (=?/same :top-level)]}

--- a/test/resources/duplicate_scopes.sql
+++ b/test/resources/duplicate_scopes.sql
@@ -1,0 +1,9 @@
+-- This is a minimal example to illustrate why we need to put an id on each scope.
+-- As we add more complex compound query tests this will become redundant, and we can then delete it
+-- we eventually want to check that the fields are cycled twice in the attribution of the final outputs.
+WITH b AS (SELECT x FROM a),
+     c AS (SELECT x FROM a)
+SELECT
+    b.x,
+    c.x
+FROM b, c;


### PR DESCRIPTION
Refs https://github.com/metabase/metabase/issues/42586

In order to track the provenance of query outputs we will need to follow the flow of data from the source table columns, through the various scopes, to the final top-level expression.

In essence we replace each string label in the in the `:context` vector with a `[label, integer-id]` pair, so that we can tell when two scopes are the same, and in future use these references to build a DAG of the data dependencies.

The test here is very basic, it just checks that our set representation does not de-duplicate the contents of the identical sub-selects. This satisfies the TDD gods[^1], but isn't that useful on its own. 

It'll be superseded when we get to more complex queries, but we're quite a way off from supporting the examples I have in mind.

[^1]: Actually I lied, and didn't write the test first, and then when I checked I was telling the truth I discovered that they already wouldn't be de-duplicated as Macaw tracks the second CTE's scope as nested within the first one. Well, I still think it's a useful minimal test for establishing which IDs should match and which shouldn't.