### PR TITLE
Fix analysis of SQL queries with consecutive line breaks

### DIFF
--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -37,9 +37,15 @@
 
 from foo")
 
+(defn- ->windows [sql]
+  (str/replace sql "\n" "\r\n"))
+
 (deftest three-or-more-line-breaks-test
-  (is (= (str/replace implicit-semicolon "id" "pk")
-         (m/replace-names implicit-semicolon {:columns {{:table "foo" :column "id"} "pk"}}))))
+  (doseq [f [identity ->windows]
+          :let [query (f implicit-semicolon)]]
+    (is (= (str/replace query "id" "pk")
+           (m/replace-names query
+                            {:columns {{:table "foo" :column "id"} "pk"}})))))
 
 (deftest query->tables-test
   (testing "Simple queries"

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -30,6 +30,17 @@
                  {:column-qualifier (fn [acc tbl _ctx] (conj acc (.getName ^Table tbl)))}
                  #{}))
 
+;; See [[macaw.core/parsed-query]] and https://github.com/JSQLParser/JSqlParser/issues/1988 for more details.
+(def ^:private implicit-semicolon
+  "select id
+
+
+from foo")
+
+(deftest three-or-more-line-breaks-test
+  (is (= (str/replace implicit-semicolon "id" "pk")
+         (m/replace-names implicit-semicolon {:columns {{:table "foo" :column "id"} "pk"}}))))
+
 (deftest query->tables-test
   (testing "Simple queries"
     (is (= #{{:table "core_user"}}


### PR DESCRIPTION
See https://metaboat.slack.com/archives/C06M1DD9F1B/p1718145579469589

Not sure how much of a factor this is, but ~60% of native queries are crashing Macaw on Stats right now.