### PR TITLE
Support qualified replacement targets

### DIFF
--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -84,7 +84,7 @@
     (when-let [schema-rename (u/seek (comp (partial u/match-component schema-name) key) schema-renames)]
       (vswap! updated-nodes conj [raw-schema-name schema-rename])
       (let [identifier (as-> (val schema-rename) % (:table % %))]
-        (.setSchemaName t schema-rename)))))
+        (.setSchemaName t identifier)))))
 
 (defn- rename-column
   [updated-nodes column-renames known-columns ^Column c _ctx]

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -26,7 +26,9 @@
 (def tables         (comp raw-components :tables components))
 (def table-wcs      (comp raw-components :table-wildcards components))
 
-(defn- strip-context-ids [m]
+(defn- strip-context-ids
+  "Strip the scope id from the context stacks, to get deterministic values for testing."
+  [m]
   (walk/prewalk
    (fn [x]
      (if (:context x)
@@ -382,6 +384,23 @@ from foo")
          (m/replace-names "SELECT a.x, b.x, b.y FROM a, b;"
                           {:tables  {{:schema "public" :table "a"} "aa"}
                            :columns {{:schema "public" :table "a" :column "x"} "xx"}})))
+
+  (testing "Handle fully qualified replacement targets"
+    ;; Giving Macaw more context could make it easier to
+    ;; In any case, this is trivial for Metabase to provide.
+    (is (= "SELECT aa.xx, b.x, b.y FROM aa, b;"
+           (m/replace-names "SELECT a.x, b.x, b.y FROM a, b;"
+                            {:tables  {{:schema "public" :table "a"} "aa"}
+                             :columns {{:schema "public" :table "a"  :column "x"}
+                                       {:schema "public" :table "aa" :column "xx"}}}))))
+
+  ;; To consider - we could avoid splitting up the renames into column and table portions in the client, as
+  ;; qualified targets would allow us to infer such changes. Partial qualification could also work fine where there
+  ;; is no ambiguity - even if this is just a nice convenience for testing.
+  #_(is (= "SELECT aa.xx, b.x, b.y FROM aa, b;"
+         (m/replace-names "SELECT a.x, b.x, b.y FROM a, b;"
+                          {:columns {{:schema "public" :table "a" :column "x"}
+                                     {:table "aa" :column "xx"}}})))
 
   (is (= "SELECT qwe FROM orders"
          (m/replace-names "SELECT id FROM orders"


### PR DESCRIPTION
We haven't wired up Metabase to use this functionality, but when we do it'll be easier to just pass the same format for both the source and target elements. 

This extra context may also help Macaw do the-right-thing™️ when it could otherwise introduce ambiguity, I think. I swear I thought of a case last week, but I've forgotten it. So the main rationale is the API consistency.