### PR TITLE
Avoid phantom column references from compound queries

### DIFF
--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -185,8 +185,7 @@
                                         (comp (update-components (partial make-column aliases opts))
                                               strip-non-query-contexts)
                                         columns)
-        strip-alias               (fn [c] (dissoc c :alias))
-        strip-aliases             (map #(update % :component strip-alias))]
+        strip-alias               (fn [c] (dissoc c :alias))]
     {:columns           all-columns
      :source-columns    (into #{} (map strip-alias) (remove-redundant-columns (map :component all-columns)))
      ;; result-columns ... filter out the elements (and wildcards) in the top level scope only.

--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -150,10 +150,9 @@
 (defn- remove-redundant-columns
   "Remove any unqualified references that would resolve to a given qualified reference"
   [column-set]
-  ;; TODO as far as "used columns" go, we don't really care about context, and should drop it before doing this
-  (let [{qualified true, unqualified false} (group-by (comp boolean :table :component) column-set)
-        qualifications (into #{} (mapcat #(keep (comp % :component) qualified)) [:column :alias])]
-    (into qualified (remove (comp qualifications :column :component)) unqualified)))
+  (let [{qualified true, unqualified false} (group-by (comp boolean :table) column-set)
+        qualifications (into #{} (mapcat #(keep % qualified)) [:column :alias])]
+    (into qualified (remove (comp qualifications :column)) unqualified)))
 
 (defn query->components
   "See macaw.core/query->components doc."
@@ -189,7 +188,7 @@
         strip-alias               (fn [c] (dissoc c :alias))
         strip-aliases             (map #(update % :component strip-alias))]
     {:columns           all-columns
-     :source-columns    (into #{} strip-aliases (remove-redundant-columns all-columns))
+     :source-columns    (into #{} (map strip-alias) (remove-redundant-columns (map :component all-columns)))
      ;; result-columns ... filter out the elements (and wildcards) in the top level scope only.
      :has-wildcard?     (into #{} strip-non-query-contexts has-wildcard?)
      :mutation-commands (into #{} mutation-commands)

--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -178,7 +178,8 @@
         table-map                 (merge-with merge-with-instances qualifier-map table-map)
         raw-columns               (into #{} (update-components (partial make-column opts)) columns)
         strip-alias               (fn [c] (dissoc c :alias))]
-    {:columns           (into #{} (map #(update % :component strip-alias)) (remove-redundancies raw-columns))
+    {:columns           raw-columns
+     :source-columns    (into #{} (map #(update % :component strip-alias)) (remove-redundancies raw-columns))
      :elements          (into #{} (map #(update % :component strip-alias)) raw-columns)
      :has-wildcard?     (into #{} (update-components (fn [x & _args] x)) has-wildcard?)
      :mutation-commands (into #{} mutation-commands)

--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -114,12 +114,12 @@
          table-renames  :tables
          column-renames :columns} renames
         comps          (collect/query->components parsed-ast (assoc opts :with-instance true))
-        elements       (index-by-instances (:elements comps))
+        columns        (index-by-instances (:columns comps))
         tables         (index-by-instances (:tables comps))
         ;; execute rename
         updated-nodes  (volatile! [])
         rename-table*  (partial rename-table updated-nodes table-renames schema-renames tables opts)
-        rename-column* (partial rename-column updated-nodes column-renames elements)
+        rename-column* (partial rename-column updated-nodes column-renames columns)
         res            (-> parsed-ast
                            (mw/walk-query
                             {:table            rename-table*

--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -114,12 +114,12 @@
          table-renames  :tables
          column-renames :columns} renames
         comps          (collect/query->components parsed-ast (assoc opts :with-instance true))
-        columns        (index-by-instances (:columns comps))
+        elements       (index-by-instances (:elements comps))
         tables         (index-by-instances (:tables comps))
         ;; execute rename
         updated-nodes  (volatile! [])
         rename-table*  (partial rename-table updated-nodes table-renames schema-renames tables opts)
-        rename-column* (partial rename-column updated-nodes column-renames columns)
+        rename-column* (partial rename-column updated-nodes column-renames elements)
         res            (-> parsed-ast
                            (mw/walk-query
                             {:table            rename-table*

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -565,7 +565,7 @@ from foo")
 (deftest duplicate-scopes-test
   ;; TODO We must mention the columns with "a" as their source table, otherwise we cannot compute the source fields.
   ;; TODO Fix kondo linting of =?/same
-  #_{:clj-kondo/ignore [:unresolved-symbol]}
+  ^:clj-kondo/ignore
   (is (=? [#_{:component {:table "a", :column "x"}, :scope ["SELECT" (=?/same :subselect-1)]}
            #_{:component {:table "a", :column "x"}, :scope ["SELECT" (=?/same :subselect-2)]}
            {:component {:table "b", :column "x"}, :scope ["SUB_SELECT" (=?/same :top-level)]}

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -588,11 +588,7 @@ from foo")
            (source-columns "SELECT COUNT(DISTINCT(id)) FROM users")))))
 
 (deftest compound-subselect-test
-  ;; TODO These first three entries should track what they're derived from, so we can filter them from query fields.
-  (is (= [{:column "average_salary", :alias "avg_salary"}
-          {:column "department", :alias "department_name"}
-          {:column "department"}
-          ;; TODO This doesn't belong here, as the identifier does not relate to any column
+  (is (= [;; TODO This doesn't belong here, as the identifier does not relate to any column
           {:column "total_employees"}
           {:table "employees", :column "department"}
           {:table "employees", :column "salary"}]

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -350,6 +350,8 @@ from foo")
   (is (= #{{:table "foo"}}
          (table-wcs "SELECT f.* FROM orders o JOIN foo f ON orders.id = foo.order_id"))))
 
+;; TODO Fix kondo linting of =? (strangely enough I don't need this locally)
+^:clj-kondo/ignore
 (deftest context-test
   (testing "Sub-select with outer wildcard"
     ;; TODO we should test the source and result columns too

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -622,7 +622,7 @@ from foo")
           {:table "employees", :column "salary"}]
          (sorted (source-columns (query-fixture :compound/correlated-subquery))))))
 
-(deftest phatom-tables-test
+(deftest phantom-tables-test
   (is (= #{{:table "a"}
            ;; these are actually aliases to internal scopes, we should not list them
            {:table "b"}

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -619,8 +619,8 @@ from foo")
   (is (= #{{:table "a"}
            ;; these are actually aliases to internal scopes, we should not list them
            {:table "b"}
-           {:table "c"}})
-      (tables (query-fixture :duplicate-scopes)))
+           {:table "c"}}
+         (tables (query-fixture :duplicate-scopes))))
   (is (= #{#_{:table "a", :column "x"}
            ;; These two internal references are being confused for qualified source references.
            ;; This causes us to remove the inner unqualified reference.

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -638,6 +638,7 @@ from foo")
   #_(is (= #{} (columns (query-fixture :cycle/cte)))))
 
 (comment
+ (require 'hashp.core)
  (require 'virgil)
  (require 'clojure.tools.namespace.repl)
  (virgil/watch-and-recompile ["java"] :post-hook clojure.tools.namespace.repl/refresh-all)

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -40,7 +40,9 @@
        x))
    m))
 
-(defn- contexts->scopes [m]
+(defn- contexts->scopes
+  "Replace full context stack with a reference to the local scope, only."
+  [m]
   (walk/prewalk
    (fn [x]
      (if-let [context (:context x)]

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -21,9 +21,6 @@
 
 (def components     (comp m/query->components m/parsed-query))
 (def raw-components #(let [xs (empty %)] (into xs (keep :component) %)))
-;; TODO we should rename this to "source-columns" or something, to be clearer.
-;;      some of these tests are still related to this superset, and other will want to talk about "result-columns"
-;;      we probably want to test both source and result columns for everything...
 (def columns        (comp raw-components :columns components))
 (def source-columns (comp :source-columns components))
 (def has-wildcard?  (comp non-empty-and-truthy raw-components :has-wildcard? components))


### PR DESCRIPTION
Refs https://github.com/metabase/metabase/issues/42586

### Description

We introduce the new `source-columns` subset of column identifiers, which strips out intermediate column identifiers and returns only the real columns read from actual tables. The overloading of the word `columns` here is unfortunate, but we inherit it from JSQLParser.

### What changed?

- We introduce the new `:source-columns` return key from `query->components`
- This collection strips out unqualified references which are redundant with other qualified references, as well as references to aliases.
- This all still operates in a "flat scope", i.e. there are definitely bugs to track down for nested queries.

### What does this mean for Metabase?

Metabase will need to move from using `:columns` to using `:source-columns` for creating `QueryField` instances.