### PR TITLE
Handle pseudo tables from subselects and CTEs

### DIFF
--- a/src/macaw/walk.clj
+++ b/src/macaw/walk.clj
@@ -10,6 +10,7 @@
   {:column           AstWalker$CallbackKey/COLUMN
    :column-qualifier AstWalker$CallbackKey/COLUMN_QUALIFIER
    :mutation         AstWalker$CallbackKey/MUTATION_COMMAND
+   :pseudo-table     AstWalker$CallbackKey/PSEUDO_TABLES
    :table            AstWalker$CallbackKey/TABLE
    :table-wildcard   AstWalker$CallbackKey/ALL_TABLE_COLUMNS
    :wildcard         AstWalker$CallbackKey/ALL_COLUMNS})


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44046

### Description

This fixes the fact that non-tables could appear in both the `:tables` result and the `:table` field of the `:source-columns` result.

This method fixes most of the existing tests without breaking any others, but it is *not* correct in the general case. The problem is that it still operates at a "flat" scope, so if there is shadowing or punning then we can still emit garbage column/table combinations.