### PR TITLE
Fix phantom wildcards

### DIFF
--- a/java/com/metabase/macaw/AstWalker.java
+++ b/java/com/metabase/macaw/AstWalker.java
@@ -625,7 +625,10 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
     @Override
     public void visit(ExpressionList<?> expressionList) {
         for (Expression expression : expressionList) {
-            expression.accept(this);
+            // The use of a wildcard within a function means "nothing".
+            if (!(expression instanceof AllColumns)) {
+                expression.accept(this);
+            }
         }
     }
 

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -563,7 +563,7 @@ from foo")
 (deftest count-field-test
   (testing "COUNT(*) does not actually read any columns"
     (is (empty? (columns "SELECT COUNT(*) FROM users")))
-    #_(is (false? (has-wildcard? "SELECT COUNT(*) FROM users")))
+    (is (false? (has-wildcard? "SELECT COUNT(*) FROM users")))
     (is (empty? (table-wcs "SELECT COUNT(*) FROM users"))))
   (testing "COUNT(1) does not actually read any columns"
     (is (empty? (columns "SELECT COUNT(1) FROM users")))
@@ -640,4 +640,11 @@ from foo")
  (anonymize-query "SELECT x FROM a")
  (anonymize-fixture :snowflake)
  (anonymize-fixture :snowflakelet)
+
  )
+
+;; Useful for stepping through debugger on save.
+#_(let [sql "SELECT COUNT(*) FROM bar"
+        ;; sql (query-fixture :duplicate-scopes)
+        q   (m/parsed-query sql)]
+    (components q))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/44380

I can't think of any case where using a wildcard within an expression still means "every column".

I would have preferred to check whether the parent of the node was a `SelectItem`, but couldn't find a reliable way to do so without fancy state twiddling.