### PR TITLE
Demonstrate the we no longer get phantom source columns from references to column-less expressions

### DIFF
--- a/java/com/metabase/macaw/AstWalker.java
+++ b/java/com/metabase/macaw/AstWalker.java
@@ -164,6 +164,7 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
        SelectItemVisitor, StatementVisitor, GroupByVisitor {
 
     public enum CallbackKey {
+        ALIAS,
         ALL_COLUMNS,
         ALL_TABLE_COLUMNS,
         COLUMN,
@@ -850,6 +851,8 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
         if (alias != null) {
             // FIXME: this is absolutely a hack, what's the best way to get around it?
             pushContext("alias", alias.getName());
+            // This should be able to replace it.
+            invokeCallback(ALIAS, item);
         }
         item.getExpression().accept(this);
         if (alias != null) {

--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -163,7 +163,7 @@
           unqualified)))
 
 (defn- remove-phantoms [table-alias? columns]
-  (distinct (filter (comp #(or (nil? %) (table? %)) :table) columns)))
+  (distinct (filter (comp #(or (nil? %) (table-alias? %)) :table) columns)))
 
 (defn query->components
   "See macaw.core/query->components doc."

--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -163,7 +163,7 @@
           unqualified)))
 
 (defn- remove-phantoms [table-alias? columns]
-  (distinct (filter (comp #(or (nil? %) (table-alias? %)) :table) columns)))
+  (distinct (filter (comp #(or (nil? %) (not (table-alias? %))) :table) columns)))
 
 (defn query->components
   "See macaw.core/query->components doc."

--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -9,7 +9,7 @@
    (net.sf.jsqlparser.expression Alias)
    (net.sf.jsqlparser.schema Column Table)
    (net.sf.jsqlparser.statement Statement)
-   (net.sf.jsqlparser.statement.select AllTableColumns)))
+   (net.sf.jsqlparser.statement.select AllTableColumns SelectItem)))
 
 (set! *warn-on-reflection* true)
 
@@ -27,13 +27,17 @@
 (defn- query->raw-components
   [^Statement parsed-ast]
   (mw/fold-query parsed-ast
-                 {:column           (conj-to :columns)
+                 {:alias            (conj-to :aliases (fn [^SelectItem item]
+                                                        {:alias      (.getName (.getAlias item))
+                                                         :expression (.getExpression item)}))
+                  :column           (conj-to :columns)
                   :column-qualifier (conj-to :qualifiers)
                   :mutation         (conj-to :mutation-commands)
                   :wildcard         (conj-to :has-wildcard? (constantly true))
                   :table            (conj-to :tables)
                   :table-wildcard   (conj-to :table-wildcards)}
-                 {:columns           #{}
+                 {:aliases           #{}
+                  :columns           #{}
                   :has-wildcard?     #{}
                   :mutation-commands #{}
                   :tables            #{}
@@ -148,16 +152,24 @@
       cs-a (update-in [:component :instances] into cs-a))))
 
 (defn- remove-redundant-columns
-  "Remove any unqualified references that would resolve to a given qualified reference"
-  [column-set]
+  "Remove any unqualified references that would resolve to an alias or qualified reference"
+  [alias? column-set]
   (let [{qualified true, unqualified false} (group-by (comp boolean :table) column-set)
-        qualifications (into #{} (mapcat #(keep % qualified)) [:column :alias])]
-    (into qualified (remove (comp qualifications :column)) unqualified)))
+        ;; Get all the bindings introduced by qualified columns
+        has-qualification? (into #{} (mapcat #(keep % qualified)) [:column :alias])]
+    (into qualified
+          (remove (comp (some-fn alias? has-qualification?)
+                        :column))
+          unqualified)))
+
+(defn- remove-phantoms [table-alias? columns]
+  (distinct (filter (comp #(or (nil? %) (table? %)) :table) columns)))
 
 (defn query->components
   "See macaw.core/query->components doc."
   [^Statement parsed-ast & {:as opts}]
-  (let [{:keys [columns
+  (let [{:keys [aliases
+                columns
                 qualifiers
                 has-wildcard?
                 mutation-commands
@@ -175,23 +187,26 @@
         qualifier-map             (->> (update-components (partial find-qualifier-table opts) qualifiers)
                                        (u/group-with #(select-keys (:component %) [:schema :table])
                                                      merge-with-instances))
-        table-map                 (merge-with merge-with-instances qualifier-map table-map)
-        ;; TODO clean this overwrought two-phase calculation up
-        aliases                   (into #{} (comp (update-components (partial make-column #{} {}))
-                                                  (keep (comp :alias :component))
-                                                  (distinct))
-                                        columns)
+        table-map                 (into {} (remove (comp (set (keys qualifier-map)) key))
+                                        table-map)
+        real-tables               (into #{} (comp (map val)
+                                                  strip-non-query-contexts)
+                                        table-map)
+        alias?                    (into #{} (keep (comp :alias :component)) aliases)
         all-columns               (into #{}
-                                        (comp (update-components (partial make-column aliases opts))
+                                        (comp (update-components (partial make-column alias? opts))
                                               strip-non-query-contexts)
                                         columns)
         strip-alias               (fn [c] (dissoc c :alias))]
     {:columns           all-columns
-     :source-columns    (into #{} (map strip-alias) (remove-redundant-columns (map :component all-columns)))
+     :source-columns    (->> (map :component all-columns)
+                             (remove-phantoms (into #{} (keep (comp :table :component)) real-tables))
+                             (remove-redundant-columns alias?)
+                             (into #{} (map strip-alias)))
      ;; result-columns ... filter out the elements (and wildcards) in the top level scope only.
      :has-wildcard?     (into #{} strip-non-query-contexts has-wildcard?)
      :mutation-commands (into #{} mutation-commands)
-     :tables            (into #{} (comp (map val) strip-non-query-contexts) table-map)
+     :tables            real-tables
      :table-wildcards   (into #{}
                               (comp strip-non-query-contexts
                                     (update-components (partial resolve-table-name opts)))

--- a/src/macaw/walk.clj
+++ b/src/macaw/walk.clj
@@ -7,7 +7,8 @@
 (def ->callback-key
   "keyword->key map for the AST-folding callbacks."
   ;; TODO: Move this to a Malli schema to simplify the indirection
-  {:column           AstWalker$CallbackKey/COLUMN
+  {:alias            AstWalker$CallbackKey/ALIAS
+   :column           AstWalker$CallbackKey/COLUMN
    :column-qualifier AstWalker$CallbackKey/COLUMN_QUALIFIER
    :mutation         AstWalker$CallbackKey/MUTATION_COMMAND
    :table            AstWalker$CallbackKey/TABLE

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -616,10 +616,7 @@ from foo")
          (sorted (source-columns (query-fixture :compound/correlated-subquery))))))
 
 (deftest phantom-tables-test
-  (is (= #{{:table "a"}
-           ;; these are actually aliases to internal scopes, we should not list them
-           {:table "b"}
-           {:table "c"}}
+  (is (= #{{:table "a"}}
          (tables (query-fixture :duplicate-scopes))))
   (is (= #{#_{:table "a", :column "x"}
            ;; These two internal references are being confused for qualified source references.

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -571,6 +571,9 @@ from foo")
            {:component {:table "c", :column "x"}, :scope ["SUB_SELECT" (=?/same :top-level)]}]
           (sorted (contexts->scopes (:columns (components (query-fixture :duplicate-scopes))))))))
 
+(deftest no-source-columns-test
+  (is (empty? (source-columns (query-fixture :no-source-columns)))))
+
 (deftest count-field-test
   (testing "COUNT(*) does not actually read any columns"
     (is (empty? (columns "SELECT COUNT(*) FROM users")))

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -588,8 +588,8 @@ from foo")
            (source-columns "SELECT COUNT(DISTINCT(id)) FROM users")))))
 
 (deftest compound-subselect-test
-  (is (= [;; TODO This doesn't belong here, as the identifier does not relate to any column
-          {:column "total_employees"}
+  ;; this is a phantom column
+  (is (= [{:column "total_employees"}
           {:table "employees", :column "department"}
           {:table "employees", :column "salary"}]
          (sorted (source-columns (query-fixture :compound/subselect))))))
@@ -641,7 +641,7 @@ from foo")
  (require 'hashp.core)
  (require 'virgil)
  (require 'clojure.tools.namespace.repl)
- (virgil/watch-and-recompile ["java"] :post-hook clojure.tools.namespace.repl/refresh-all)
+ (virgil/watch-and-recompile  :post-hook clojure.tools.namespace.repl/refresh-all)
 
  (anonymize-query "SELECT x FROM a")
  (anonymize-fixture :snowflake)

--- a/test/resources/no_source_columns.sql
+++ b/test/resources/no_source_columns.sql
@@ -1,0 +1,2 @@
+WITH cte AS (SELECT COUNT(*) AS a FROM foo)
+SELECT a AS b FROM bar


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44045

Turns out we already fixed this incidentally.