### PR TITLE
Fix column-less aliases resulting in phantom source columns

### DIFF
--- a/java/com/metabase/macaw/AstWalker.java
+++ b/java/com/metabase/macaw/AstWalker.java
@@ -164,6 +164,7 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
        SelectItemVisitor, StatementVisitor, GroupByVisitor {
 
     public enum CallbackKey {
+        ALIAS,
         ALL_COLUMNS,
         ALL_TABLE_COLUMNS,
         COLUMN,
@@ -861,6 +862,8 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
         if (alias != null) {
             // FIXME: this is absolutely a hack, what's the best way to get around it?
             pushContext("alias", alias.getName());
+            // This should be able to replace it.
+            invokeCallback(ALIAS, item);
         }
         item.getExpression().accept(this);
         if (alias != null) {

--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -115,7 +115,7 @@
          column-renames :columns} renames
         comps          (collect/query->components parsed-ast (assoc opts :with-instance true))
         columns        (index-by-instances (:columns comps))
-        tables         (index-by-instances (:tables comps))
+        tables         (index-by-instances (:tables-superset comps))
         ;; execute rename
         updated-nodes  (volatile! [])
         rename-table*  (partial rename-table updated-nodes table-renames schema-renames tables opts)

--- a/src/macaw/walk.clj
+++ b/src/macaw/walk.clj
@@ -7,7 +7,8 @@
 (def ->callback-key
   "keyword->key map for the AST-folding callbacks."
   ;; TODO: Move this to a Malli schema to simplify the indirection
-  {:column           AstWalker$CallbackKey/COLUMN
+  {:alias            AstWalker$CallbackKey/ALIAS
+   :column           AstWalker$CallbackKey/COLUMN
    :column-qualifier AstWalker$CallbackKey/COLUMN_QUALIFIER
    :mutation         AstWalker$CallbackKey/MUTATION_COMMAND
    :pseudo-table     AstWalker$CallbackKey/PSEUDO_TABLES

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -570,6 +570,9 @@ from foo")
            {:component {:table "c", :column "x"}, :scope ["SUB_SELECT" (=?/same :top-level)]}]
           (sorted (contexts->scopes (:columns (components (query-fixture :duplicate-scopes))))))))
 
+(deftest no-source-columns-test
+  (is (empty? (source-columns (query-fixture :no-source-columns)))))
+
 (deftest count-field-test
   (testing "COUNT(*) does not actually read any columns"
     (is (empty? (columns "SELECT COUNT(*) FROM users")))

--- a/test/resources/no_source_columns.sql
+++ b/test/resources/no_source_columns.sql
@@ -1,0 +1,2 @@
+WITH cte AS (SELECT COUNT(*) AS a FROM foo)
+SELECT a AS b FROM bar


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/44045

A bit of a mouthful. 

The issue was that referring to a non-column alias could result in the Macaw interpreting those references as coming directly from one of the source tables. This was due to the fact that we ignoring aliases that were not introduced by named column references.

Clarifying example:

```SQL
WITH cte AS (SELECT COUNT(*) AS a FROM foo)
SELECT a AS b FROM bar
```

Without this fix, we would have inferred `{:table "bar" :column "a"}` as a source column.