### PR TITLE
Support MSSQL square bracket quotes

### DIFF
--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -47,12 +47,14 @@
 
 ;;; tables
 
-(def ^:private quotes (map str [\` \"]))
+(def ^:private quotes (map str "`\"["))
+
+(def ^:private closing {"[" "]"})
 
 (defn- quoted? [s]
   (some (fn [q]
           (and (str/starts-with? s q)
-               (str/ends-with? s q)))
+               (str/ends-with? s (closing q q))))
         quotes))
 
 (defn- strip-quotes [s]

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -604,6 +604,16 @@ from foo")
                              :columns {{:table "x" :column "final"} "y"}}
                             {:non-reserved-words [:final]})))))
 
+(deftest square-bracket-test
+  (testing "We can opt into allowing square brackets to quote things"
+    (is (=? {:tables  #{{:schema "s" :table "t"}}
+             :columns #{{:schema "s" :table "t" :column "f"}}}
+            (update-vals
+             (components "SELECT [f] FROM [s].[t]"
+                         {:features              {:square-bracket-quotes true}
+                          :preserve-identifiers? false})
+             raw-components)))))
+
 (comment
  (require 'hashp.core)
  (require 'virgil)

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -19,7 +19,9 @@
     (every? true? xs)
     false))
 
-(def components     (comp m/query->components m/parsed-query))
+(defn components [sql & {:as opts}]
+  (m/query->components (m/parsed-query sql opts) opts))
+
 (def raw-components #(let [xs (empty %)] (into xs (keep :component) %)))
 (def columns        (comp raw-components :columns components))
 (def source-columns (comp :source-columns components))
@@ -87,7 +89,6 @@ from foo")
   (testing "Sub-selects"
     (is (= #{{:table "core_user"}}
            (tables "SELECT * FROM (SELECT DISTINCT email FROM core_user) q;")))))
-
 
 (deftest tables-with-complex-aliases-issue-14-test
   (testing "With an alias that is also a table name"
@@ -314,8 +315,8 @@ from foo")
 
 (deftest complicated-mutations-test
   ;; https://github.com/metabase/macaw/issues/18
-  #_  (is (= #{"delete" "insert"}
-             (mutations "WITH outdated_orders AS (
+  #_(is (= #{"delete" "insert"}
+           (mutations "WITH outdated_orders AS (
                        DELETE FROM orders
                        WHERE
                          date <= '2018-01-01'


### PR DESCRIPTION
Refs https://github.com/metabase/macaw/issues/42

We need to also enable this feature for the corresponding driver in Metabase.

Perhaps out of convenience we should just start passing the driver through for now, we can always decouple things a bit more later...