### PR TITLE
Add timeout with default to 5s

### DIFF
--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -31,9 +31,12 @@
 (defn- ->Feature ^Feature [k]
   (get features k))
 
+(def ^:private default-timeout-seconds 5)
+
 (defn- ->parser-fn ^Consumer [opts]
   (reify Consumer
     (accept [_this parser]
+      (.withFeature ^CCJSqlParser parser Feature/timeOut (:timeout opts (* default-timeout-seconds 1000)))
       (doseq [[f ^boolean v] (:features opts)]
         (.withFeature ^CCJSqlParser parser (->Feature f) v)))))
 

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -36,7 +36,7 @@
 (defn- ->parser-fn ^Consumer [opts]
   (reify Consumer
     (accept [_this parser]
-      (let [timeout-ms ^long (:timeout opts (* default-timeout-seconds 1000))]
+      (let [^long timeout-ms (:timeout opts (* default-timeout-seconds 1000))]
         (.withFeature ^CCJSqlParser parser Feature/timeOut timeout-ms))
       (doseq [[f ^boolean v] (:features opts)]
         (.withFeature ^CCJSqlParser parser (->Feature f) v)))))

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -36,7 +36,8 @@
 (defn- ->parser-fn ^Consumer [opts]
   (reify Consumer
     (accept [_this parser]
-      (.withFeature ^CCJSqlParser parser Feature/timeOut (:timeout opts (* default-timeout-seconds 1000)))
+      (let [timeout-ms ^long (:timeout opts (* default-timeout-seconds 1000))]
+        (.withFeature ^CCJSqlParser parser Feature/timeOut timeout-ms))
       (doseq [[f ^boolean v] (:features opts)]
         (.withFeature ^CCJSqlParser parser (->Feature f) v)))))
 


### PR DESCRIPTION
We should probably put a limit on how long we'll try to parse something. This PR adds a `:timeout` parameter, whose default value is 5s.