### PR TITLE
Add working query using BETWEEN to compare

### DIFF
--- a/java/com/metabase/macaw/AstWalker.java
+++ b/java/com/metabase/macaw/AstWalker.java
@@ -294,7 +294,7 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
      * Fold the given `statement`, using the callbacks to update the accumulator as appropriate.
      */
     public Acc fold(Statement statement) {
-        statement.accept(this);
+        maybeAcceptThis(statement);
         return this.acc;
     }
 
@@ -762,6 +762,12 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
     private void maybeAcceptThis(Expression expression) {
         if (expression != null) {
             expression.accept(this);
+        }
+    }
+
+    private void maybeAcceptThis(Statement statement) {
+        if (statement != null) {
+            statement.accept(this);
         }
     }
 

--- a/test/resources/acceptance/between__working.sql
+++ b/test/resources/acceptance/between__working.sql
@@ -1,0 +1,3 @@
+SELECT count(*)
+FROM t
+WHERE CAST(created_at AS date) BETWEEN DATE '2021-08-01' AND DATE '2021-09-30';

--- a/test/resources/acceptance/broken__between.sql
+++ b/test/resources/acceptance/broken__between.sql
@@ -1,12 +1,7 @@
-SELECT date_trunc('month', instance_started)::date as month_started, count(*) AS "total_instances",
-    avg(ts-instance_started) as avg_runtime,
-    avg((stats->'user'->'users'->>'active')::int) as avg_active_users,
-    percentile_disc(0.9) within group (order by (stats->'user'->'users'->>'active')::int) as p90_active_users,
-    avg((stats->'question'->'questions'->>'total')::int) as avg_questions,
-    percentile_disc(0.9) within group (order by (stats->'question'->'questions'->>'total')::int) as p90_questions,
-    max((stats->'question'->'questions'->>'total')::int) as max_questions
-  FROM "public"."usage_stats"
-  WHERE (("public"."usage_stats"."instance_started" BETWEEN timestamp
-    with time zone '2019-01-01 00:00:00.000-08:00' AND NOW()) AND ts-instance_started < INTERVAL '30 days')
-  GROUP BY 1
-  ORDER BY 1 ASC
+SELECT
+    date_trunc('month', instance_started)::DATE AS month_started,
+    avg(time_finished - instance_started) as avg_runtime,
+    count(*) AS total_instances
+  FROM usage_stats
+  WHERE instance_started BETWEEN TIMESTAMP WITH TIME ZONE '2019-01-01 00:00:00.000-08:00' AND NOW();
+  GROUP BY month_started;


### PR DESCRIPTION
Added a working query which uses `BETWEEN`, and shrunk down the broken example a bit.

Totally flummoxed why one works and one doesn't.