### PR TITLE
Crude memory profiling in REPL

### DIFF
--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -64,7 +64,7 @@
   ;; This may result in duplicate components, which are left to the caller to deduplicate.
   ;; In Metabase's case, this is done during the stage where the database metadata is queried.
   (->> (collect/query->components statement (merge {:preserve-identifiers? true} opts))
-       (walk/prewalk (fn [x]
+       (walk/postwalk (fn [x]
                        (if (string? x)
                          (unescape-keywords x (:non-reserved-words opts))
                          x)))))
@@ -86,7 +86,7 @@
   ;; If we decide that it's OK to normalize whitespace etc. during replacement, then we can use the same helper.
   (let [sql'     (escape-keywords (str/replace sql #"(?m)^\n" " \n") (:non-reserved-words opts))
         opts'    (select-keys opts [:case-insensitive :quotes-preserve-case? :allow-unused?])
-        renames' (walk/prewalk (fn [x]
+        renames' (walk/postwalk (fn [x]
                                  (if (string? x)
                                    (escape-keywords x (:non-reserved-words opts))
                                    x))

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -65,9 +65,9 @@
   ;; In Metabase's case, this is done during the stage where the database metadata is queried.
   (->> (collect/query->components statement (merge {:preserve-identifiers? true} opts))
        (walk/postwalk (fn [x]
-                       (if (string? x)
-                         (unescape-keywords x (:non-reserved-words opts))
-                         x)))))
+                        (if (string? x)
+                          (unescape-keywords x (:non-reserved-words opts))
+                          x)))))
 
 (defn replace-names
   "Given an SQL query, apply the given table, column, and schema renames.
@@ -87,10 +87,10 @@
   (let [sql'     (escape-keywords (str/replace sql #"(?m)^\n" " \n") (:non-reserved-words opts))
         opts'    (select-keys opts [:case-insensitive :quotes-preserve-case? :allow-unused?])
         renames' (walk/postwalk (fn [x]
-                                 (if (string? x)
-                                   (escape-keywords x (:non-reserved-words opts))
-                                   x))
-                               renames)
+                                  (if (string? x)
+                                    (escape-keywords x (:non-reserved-words opts))
+                                    x))
+                                renames)
         parsed   (parsed-query sql' opts)]
     (-> (rewrite/replace-names sql' parsed renames' opts')
         (str/replace #"(?m)^ \n" "\n")

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -615,29 +615,29 @@ from foo")
              raw-components)))))
 
 (comment
- (require '[clj-async-profiler.core :as prof])
- (prof/serve-ui 8080)
+  (require 'user) ;; kondo, really
+  (require '[clj-async-profiler.core :as prof])
+  (prof/serve-ui 8080)
 
+  (defn- simple-benchmark []
+    (source-columns "SELECT x FROM t"))
 
- (defn- simple-benchmark []
-   (source-columns "SELECT x FROM t"))
+  (defn- complex-benchmark []
+    (count
+     (source-columns
+      (query-fixture :snowflake))))
 
- (defn- complex-benchmark []
-   (count
-    (source-columns
-     (query-fixture :snowflake))))
+  (user/time+ (simple-benchmark))
+  (prof/profile {:event :alloc}
+    (dotimes [_ 1000] (simple-benchmark)))
 
- (user/time+ (simple-benchmark))
- (prof/profile {:event :alloc}
-   (dotimes [_ 1000] (simple-benchmark)))
+  (user/time+ (complex-benchmark))
+  (prof/profile {:event :alloc}
+    (dotimes [_ 100] (complex-benchmark)))
 
- (user/time+ (complex-benchmark))
- (prof/profile {:event :alloc}
-   (dotimes [_ 100] (complex-benchmark)))
+  (anonymize-query "SELECT x FROM a")
+  (anonymize-fixture :snowflakelet)
 
- (anonymize-query "SELECT x FROM a")
- (anonymize-fixture :snowflakelet)
-
- (require 'virgil)
- (require 'clojure.tools.namespace.repl)
- (virgil/watch-and-recompile ["java"] :post-hook clojure.tools.namespace.repl/refresh-all))
+  (require 'virgil)
+  (require 'clojure.tools.namespace.repl)
+  (virgil/watch-and-recompile ["java"] :post-hook clojure.tools.namespace.repl/refresh-all))

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -615,7 +615,6 @@ from foo")
              raw-components)))))
 
 (comment
- (require 'hashp.core)
  (require 'virgil)
  (require 'clojure.tools.namespace.repl)
  (virgil/watch-and-recompile ["java"] :post-hook clojure.tools.namespace.repl/refresh-all)

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -615,14 +615,29 @@ from foo")
              raw-components)))))
 
 (comment
- (require 'virgil)
- (require 'clojure.tools.namespace.repl)
- (virgil/watch-and-recompile ["java"] :post-hook clojure.tools.namespace.repl/refresh-all)
+ (require '[clj-async-profiler.core :as prof])
+ (prof/serve-ui 8080)
 
- (source-columns "WITH cte AS (SELECT x FROM t1) SELECT x, y FROM t2")
+
+ (defn- simple-benchmark []
+   (source-columns "SELECT x FROM t"))
+
+ (defn- complex-benchmark []
+   (count
+    (source-columns
+     (query-fixture :snowflake))))
+
+ (user/time+ (simple-benchmark))
+ (prof/profile {:event :alloc}
+   (dotimes [_ 1000] (simple-benchmark)))
+
+ (user/time+ (complex-benchmark))
+ (prof/profile {:event :alloc}
+   (dotimes [_ 100] (complex-benchmark)))
 
  (anonymize-query "SELECT x FROM a")
- (anonymize-fixture :snowflake)
  (anonymize-fixture :snowflakelet)
 
- )
+ (require 'virgil)
+ (require 'clojure.tools.namespace.repl)
+ (virgil/watch-and-recompile ["java"] :post-hook clojure.tools.namespace.repl/refresh-all))


### PR DESCRIPTION
Turns out micro benchmarks are unneeded for now, as memory usage is fairly high.

JSQLParser is responsible for a significant chunk of it, responsible for almost half of it, so there's little impetus to optimize the Clojure part right now.