### PR TITLE
Skip conversion of contexts into vectors

### DIFF
--- a/src/macaw/collect.clj
+++ b/src/macaw/collect.clj
@@ -121,21 +121,23 @@
     (when (and (= (count name->table) 1) (not (alias? (.getColumnName c))))
       (:component (val (first name->table))))))
 
+(defn- scope-type [^AstWalker$Scope s] (keyword (.getType s)))
+
 (defn- make-column [aliases opts ^Column c ctx]
   (let [{:keys [schema table]} (maybe-column-table aliases opts c)]
     (u/strip-nils
      {:schema    schema
       :table     table
       :column    (normalize-reference (.getColumnName c) opts)
-      :alias     (when-let [^AstWalker$Scope s (first ctx)]
-                   (when (= :alias (keyword (.getType s)))
-                     (.getLabel s)))
+      :alias     (when-let [s (first ctx)]
+                   (when (= :alias (scope-type s))
+                     (.getLabel ^AstWalker$Scope s)))
       :instances (when (:with-instance opts) [c])})))
 
 ;;; get them together
 
 (defn- only-query-context [ctx]
-  (filter #(= (keyword (.getType ^AstWalker$Scope %)) :query) ctx))
+  (filter #(= (scope-type %) :query) ctx))
 
 (def ^:private strip-non-query-contexts
   (map #(update % :context only-query-context)))

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -5,6 +5,7 @@
    [macaw.collect :as collect]
    [macaw.rewrite :as rewrite])
   (:import
+   (com.metabase.macaw AstWalker$Scope)
    (java.util.function Consumer)
    (net.sf.jsqlparser.parser CCJSqlParser CCJSqlParserUtil)
    (net.sf.jsqlparser.parser.feature Feature)))
@@ -53,6 +54,16 @@
       (str/replace #"\n{2,}" "\n")
       (escape-keywords (:non-reserved-words opts))
       (CCJSqlParserUtil/parse (->parser-fn opts))))
+
+(defn scope-id
+  "A unique identifier for the given scope."
+  [^AstWalker$Scope s]
+  (.getId s))
+
+(defn scope-label
+  "The type of scope we're talking about e.g., a top-level SELECT."
+  [^AstWalker$Scope s]
+  (.getLabel s))
 
 (defn query->components
   "Given a parsed query (i.e., a [subclass of] `Statement`) return a map with the elements found within it.

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -36,9 +36,12 @@
   (walk/prewalk
    (fn [x]
      (if (:context x)
-       (update x :context (partial mapv first))
+       (update x :context (partial mapv m/scope-label))
        x))
    m))
+
+(defn scope->vec [s]
+  [(m/scope-label s) (m/scope-id s)])
 
 (defn contexts->scopes
   "Replace full context stack with a reference to the local scope, only."
@@ -46,7 +49,7 @@
   (walk/prewalk
    (fn [x]
      (if-let [context (:context x)]
-       (-> x (dissoc :context) (assoc :scope (first context)))
+       (-> x (dissoc :context) (assoc :scope (scope->vec (first context))))
        x))
    m))
 


### PR DESCRIPTION
It turns out there's a big opportunity to expose the scopes directly as Java objects rather than vectors.

I tried instead just interning the conversions, but that turned out quite complex and to still use quite a bit more memory. Since we don't actually use the contexts for anything externally, this seems fine. The API has added some methods to read their properties without interop.

This is a non-breaking change for Metabase.

Before all these context optimizations:

```
> (user/time+ (complex-benchmark))
Time per call: 77.74 ms   Alloc per call: 111,128,445b   Iterations: 26
```

Afterwards (incl previous PR)

```
> (user/time+ (complex-benchmark))
Time per call: 43.94 ms   Alloc per call: 29,220,062b   Iterations: 47
```