### PR TITLE
Introduce dev/test/prod environments

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,8 @@
   :ensure "target/classes"}
 
  :deps
- {com.github.jsqlparser/jsqlparser {:mvn/version "4.9"}} ; The actual SQL Parser to wrap!
+ {com.github.jsqlparser/jsqlparser {:mvn/version "4.9"}    ; The actual SQL Parser to wrap!
+  environ/environ                  {:mvn/version "1.2.0"}} ; Get environment variables and Java properties
 
 
  :aliases
@@ -21,7 +22,8 @@
    ["test" "test/resources"]
 
    :jvm-opts
-   ["-Duser.timezone=UTC"
+   ["-Dmacaw.run.mode=dev"
+    "-Duser.timezone=UTC"
     "-Duser.language=en"
     "-Duser.country=US"
     ;; if compilation on launch fails or whatever print to console instead of a temp file.
@@ -55,7 +57,8 @@
   ;;
   ;; clojure -X:dev:test
   :test
-  {:exec-fn mb.hawk.core/find-and-run-tests-cli}
+  {:exec-fn  mb.hawk.core/find-and-run-tests-cli
+   :jvm-opts ["-Dmacaw.run.mode=test"]}
 
   ;; clojure -T:build
   :build

--- a/src/macaw/config.clj
+++ b/src/macaw/config.clj
@@ -1,0 +1,32 @@
+(ns macaw.config
+  (:require
+   [clojure.string :as str]
+   [environ.core :as env]))
+
+(def ^:private app-defaults
+  "Default configuration; could be overridden by Java properties, environment variables, etc."
+  {:macaw-run-mode "prod"})
+
+(defn- config-value
+  [k]
+  (let [env-val (get env/env k)]
+    (or (when-not (str/blank? env-val) env-val)
+        (get app-defaults k))))
+
+(def run-mode "The mode (dev/test/prod) in which Macaw is being run."
+  (some-> :macaw-run-mode config-value keyword))
+
+(defn is-dev?
+  "Is Macaw running in `dev` mode (i.e., in a REPL)?"
+  []
+  (= run-mode :dev))
+
+(defn is-test?
+  "Is Macaw running in `test` mode?"
+  []
+  (= run-mode :test))
+
+(defn is-prod?
+  "Is Macaw running in `prod` mode (i.e., from a JAR)?"
+  []
+  (= run-mode :prod))


### PR DESCRIPTION
(This is a prereq to running Malli checks in dev only)

Substantial inspiration taken from Metabase's `config.clj`. One difference is that I made `is-{dev,test,prod}?` functions instead of constants so that something like this would work:

```
(with-redefs [config/run-mode :prod]
  (config/is-prod?)) ;; => true
```

Writing unit tests for this seems like a fool's errand, but it does work.