### PR TITLE
Add failing test for phantom field from generated table

### DIFF
--- a/test/resources/acceptance/generate_series.analysis.edn
+++ b/test/resources/acceptance/generate_series.analysis.edn
@@ -1,0 +1,5 @@
+{:tables         []
+ :source-columns []
+
+ :overrides
+ {:source-columns [{:table "t", :column "day"}]}}

--- a/test/resources/acceptance/generate_series.analysis.edn
+++ b/test/resources/acceptance/generate_series.analysis.edn
@@ -1,5 +1,2 @@
 {:tables         []
- :source-columns []
-
- :overrides
- {:source-columns [{:table "t", :column "day"}]}}
+ :source-columns []}

--- a/test/resources/acceptance/generate_series.sql
+++ b/test/resources/acceptance/generate_series.sql
@@ -1,0 +1,2 @@
+SELECT t.day::date AS date
+FROM generate_series(timestamp '2021-01-01', now(), interval '1 day') AS t(day)


### PR DESCRIPTION
### Description

Affected card: https://stats.metabase.com/question/4027-active-stats-users

This is currently picking up a phantom field called `t.day` which results in a spurious "unknown table" error.

### Commits

1. Add failing test
2. Fix test by adding a filtering step