### PR TITLE
Add test for false table reference negative

### DIFF
--- a/test/resources/acceptance/compound__cte_masking.analysis.edn
+++ b/test/resources/acceptance/compound__cte_masking.analysis.edn
@@ -1,0 +1,9 @@
+{:tables         [{:table "a"}, {:table "b"}]
+ :source-columns #{{:table "b" :column "x"}
+                   {:table "a" :column "y"}}
+
+ ;; See https://github.com/metabase/metabase/issues/42586
+ :overrides
+ ;; TODO currently each table gets hidden by the other CTE
+ {:tables          []
+  :source-columns  []}}

--- a/test/resources/acceptance/compound__cte_masking.sql
+++ b/test/resources/acceptance/compound__cte_masking.sql
@@ -1,3 +1,4 @@
-WITH a AS (SELECT x FROM b),
-     b AS (SELECT x from a)
+WITH c AS (SELECT x FROM b),
+     b AS (SELECT y FROM a),
+     a AS (SELECT x FROM c)
 SELECT a.x, b.y FROM a, b

--- a/test/resources/acceptance/compound__cte_masking.sql
+++ b/test/resources/acceptance/compound__cte_masking.sql
@@ -1,0 +1,3 @@
+WITH a AS (SELECT x FROM b),
+     b AS (SELECT x from a)
+SELECT a.x, b.y FROM a, b


### PR DESCRIPTION
This is an example where a query reads from two tables, but the analyzer claims that it read from neither.