### PR TITLE
Return error values rather than throwing

### DIFF
--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -23,8 +23,10 @@
   (m/query->components (m/parsed-query sql opts) opts))
 
 (defn tables [sql & {:as opts}]
-  (let [opts (update opts :mode #(or % :ast-walker-1))]
-    (m/query->tables sql opts)))
+  (let [opts   (update opts :mode #(or % :ast-walker-1))
+        result (m/query->tables sql opts)]
+    (or (:error result)
+        (:tables result))))
 
 (def raw-components #(let [xs (empty %)] (into xs (keep :component) %)))
 (def columns        (comp raw-components :columns components))


### PR DESCRIPTION
Closes https://github.com/metabase/macaw/issues/93

In Metabase we decided to clean up error handling based on values, as opposed to a mix semantically meaningful `nil`, magic keywords, and thrown exceptions.

With this change we turn (expected) exceptions into error maps. We also wrap the `tables` in a map, to avoid an awkward untagged union with the error maps.

Metabase has been made agnostic to these API changes, so upgrading will be easy.