### PR TITLE
More testing for SQL trickery

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,9 +20,10 @@
  :aliases
  {:dev
   {:extra-deps
-   {io.github.metabase/hawk     {:mvn/version "1.0.0"}
-    virgil/virgil               {:mvn/version "0.3.0"}
-    org.clojure/tools.namespace {:mvn/version "1.4.5"}}
+   {hashp/hashp                 {:mvn/version "0.2.2"}
+    io.github.metabase/hawk     {:mvn/version "1.0.0"}
+    org.clojure/tools.namespace {:mvn/version "1.4.5"}
+    virgil/virgil               {:mvn/version "0.3.0"}}
 
    :extra-paths
    ["test" "test/resources"]

--- a/java/com/metabase/macaw/AstWalker.java
+++ b/java/com/metabase/macaw/AstWalker.java
@@ -5,8 +5,6 @@ package com.metabase.macaw;
 import clojure.lang.Cons;
 import clojure.lang.IFn;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -248,8 +246,6 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
             return value;
         }
     }
-
-    private static final String NOT_SUPPORTED_YET = "Not supported yet.";
 
     private Acc acc;
     private final EnumMap<CallbackKey, IFn> callbacks;
@@ -1030,32 +1026,32 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
 
     @Override
     public void visit(Statements stmts) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
     }
 
     @Override
     public void visit(Execute execute) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
     }
 
     @Override
     public void visit(SetStatement set) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
     }
 
     @Override
     public void visit(ResetStatement reset) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
     }
 
     @Override
     public void visit(ShowColumnsStatement set) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
     }
 
     @Override
     public void visit(ShowIndexStatement showIndex) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
     }
 
     @Override

--- a/test/resources/acceptance/dynamic__select_function.analysis.edn
+++ b/test/resources/acceptance/dynamic__select_function.analysis.edn
@@ -1,0 +1,4 @@
+{:error :macaw.error/illegal-expression
+ :overrides
+ {:select-only
+  {:tables #{}}}}

--- a/test/resources/acceptance/misc__implicit_semicolons.analysis.edn
+++ b/test/resources/acceptance/misc__implicit_semicolons.analysis.edn
@@ -1,0 +1,2 @@
+{:source-columns []
+ :tables         [{:table "t"}]}

--- a/test/resources/acceptance/misc__implicit_semicolons.renames.edn
+++ b/test/resources/acceptance/misc__implicit_semicolons.renames.edn
@@ -1,0 +1,2 @@
+{:tables {{:table "t"} "s"}
+ :columns {}}

--- a/test/resources/acceptance/misc__implicit_semicolons.rewritten.sql
+++ b/test/resources/acceptance/misc__implicit_semicolons.rewritten.sql
@@ -1,0 +1,5 @@
+SELECT 1
+-- NOTE: don't remove the number of blank lines here, they're significant
+
+
+FROM s

--- a/test/resources/acceptance/misc__implicit_semicolons.sql
+++ b/test/resources/acceptance/misc__implicit_semicolons.sql
@@ -1,0 +1,5 @@
+SELECT 1
+-- NOTE: don't remove the number of blank lines here, they're significant
+
+
+FROM t

--- a/test/resources/acceptance/queries.dynamic.sql
+++ b/test/resources/acceptance/queries.dynamic.sql
@@ -1,0 +1,23 @@
+-- FIXTURE: generate-series
+SELECT t.day::date AS date
+FROM generate_series(timestamp '2021-01-01', now(), interval '1 day') AS t(day)
+
+-- FIXTURE: format
+SELECT * FROM format('%I', table_name_variable);
+
+-- FIXTURE: prepared-stmt
+EXECUTE stmt('table_name');
+
+-- FIXTURE: variable
+-- BROKEN
+EXECUTE 'SELECT * FROM ' || table_name;
+
+-- FIXTURE: call-function
+CALL user_function('table_name');
+
+-- FIXTURE: select-function
+SELECT user_function('table_name');
+
+-- FIXTURE: cursor
+-- BROKEN
+FETCH ALL FROM my_cursor;

--- a/test/resources/acceptance/queries.sql
+++ b/test/resources/acceptance/queries.sql
@@ -236,10 +236,6 @@ SELECT
     c.x
 FROM b, c;
 
--- FIXTURE: dynamic/generate-series
-SELECT t.day::date AS date
-FROM generate_series(timestamp '2021-01-01', now(), interval '1 day') AS t(day)
-
 -- FIXTURE: literal/with-table
 SELECT FALSE, 'str', 1, x FROM t
 

--- a/test/resources/acceptance/sqlserver__execute.analysis.edn
+++ b/test/resources/acceptance/sqlserver__execute.analysis.edn
@@ -1,2 +1,1 @@
-{:error     :macaw.error/invalid-query
- :overrides {:ast-walker-1 :macaw.error/unable-to-parse}}
+{:error     :macaw.error/invalid-query}

--- a/test/resources/acceptance/sqlserver__executesql.analysis.edn
+++ b/test/resources/acceptance/sqlserver__executesql.analysis.edn
@@ -1,2 +1,1 @@
-{:error     :macaw.error/invalid-query
- :overrides {:ast-walker-1 :macaw.error/unable-to-parse}}
+{:error     :macaw.error/invalid-query}


### PR DESCRIPTION
This PR improves the ergonomics for adding queries which all have the same error, and uses that to add a bunch more "skullduggery detected" fixtures.

Unfortunately I realize that a case has slipped through, and the fix is non-trivial. Needs further discussion.

Also fixed an issue where the "all the components" function was not actually catching JSQLParser exceptions.