### PR TITLE
More dynamic testing. Find a case we don't handle yet

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
 
  :deps
  {;; The actual SQL Parser to wrap!
-  com.github.jsqlparser/jsqlparser {:mvn/version "4.9"}
+  com.github.jsqlparser/jsqlparser {:mvn/version "5.0"}
   ;; Get environment variables and Java properties
   environ/environ                  {:mvn/version "1.2.0"}
   ;; Schema-checking

--- a/java/com/metabase/macaw/AstWalker.java
+++ b/java/com/metabase/macaw/AstWalker.java
@@ -12,69 +12,14 @@ import java.util.Map;
 import clojure.lang.ISeq;
 import clojure.lang.PersistentList;
 import net.sf.jsqlparser.expression.*;
-import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
-import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseAnd;
-import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseLeftShift;
-import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseOr;
-import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseRightShift;
-import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseXor;
-import net.sf.jsqlparser.expression.operators.arithmetic.Concat;
-import net.sf.jsqlparser.expression.operators.arithmetic.Division;
-import net.sf.jsqlparser.expression.operators.arithmetic.IntegerDivision;
-import net.sf.jsqlparser.expression.operators.arithmetic.Modulo;
-import net.sf.jsqlparser.expression.operators.arithmetic.Multiplication;
-import net.sf.jsqlparser.expression.operators.arithmetic.Subtraction;
+import net.sf.jsqlparser.expression.operators.arithmetic.*;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
 import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
-import net.sf.jsqlparser.expression.operators.relational.Between;
-import net.sf.jsqlparser.expression.operators.relational.ContainedBy;
-import net.sf.jsqlparser.expression.operators.relational.Contains;
-import net.sf.jsqlparser.expression.operators.relational.DoubleAnd;
-import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
-import net.sf.jsqlparser.expression.operators.relational.ExistsExpression;
-import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
-import net.sf.jsqlparser.expression.operators.relational.FullTextSearch;
-import net.sf.jsqlparser.expression.operators.relational.GeometryDistance;
-import net.sf.jsqlparser.expression.operators.relational.GreaterThan;
-import net.sf.jsqlparser.expression.operators.relational.GreaterThanEquals;
-import net.sf.jsqlparser.expression.operators.relational.InExpression;
-import net.sf.jsqlparser.expression.operators.relational.IsBooleanExpression;
-import net.sf.jsqlparser.expression.operators.relational.IsDistinctExpression;
-import net.sf.jsqlparser.expression.operators.relational.IsNullExpression;
-import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
-import net.sf.jsqlparser.expression.operators.relational.LikeExpression;
-import net.sf.jsqlparser.expression.operators.relational.Matches;
-import net.sf.jsqlparser.expression.operators.relational.MemberOfExpression;
-import net.sf.jsqlparser.expression.operators.relational.MinorThan;
-import net.sf.jsqlparser.expression.operators.relational.MinorThanEquals;
-import net.sf.jsqlparser.expression.operators.relational.NotEqualsTo;
-import net.sf.jsqlparser.expression.operators.relational.RegExpMatchOperator;
-import net.sf.jsqlparser.expression.operators.relational.SimilarToExpression;
-import net.sf.jsqlparser.expression.operators.relational.TSQLLeftJoin;
-import net.sf.jsqlparser.expression.operators.relational.TSQLRightJoin;
+import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
-import net.sf.jsqlparser.statement.Block;
-import net.sf.jsqlparser.statement.Commit;
-import net.sf.jsqlparser.statement.CreateFunctionalStatement;
-import net.sf.jsqlparser.statement.DeclareStatement;
-import net.sf.jsqlparser.statement.DescribeStatement;
-import net.sf.jsqlparser.statement.ExplainStatement;
-import net.sf.jsqlparser.statement.IfElseStatement;
-import net.sf.jsqlparser.statement.PurgeObjectType;
-import net.sf.jsqlparser.statement.PurgeStatement;
-import net.sf.jsqlparser.statement.ResetStatement;
-import net.sf.jsqlparser.statement.RollbackStatement;
-import net.sf.jsqlparser.statement.SavepointStatement;
-import net.sf.jsqlparser.statement.SetStatement;
-import net.sf.jsqlparser.statement.ShowColumnsStatement;
-import net.sf.jsqlparser.statement.ShowStatement;
-import net.sf.jsqlparser.statement.StatementVisitor;
-import net.sf.jsqlparser.statement.Statement;
-import net.sf.jsqlparser.statement.Statements;
-import net.sf.jsqlparser.statement.UnsupportedStatement;
-import net.sf.jsqlparser.statement.UseStatement;
+import net.sf.jsqlparser.statement.*;
 import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.statement.alter.AlterSession;
 import net.sf.jsqlparser.statement.alter.AlterSystemStatement;
@@ -96,34 +41,18 @@ import net.sf.jsqlparser.statement.grant.Grant;
 import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.merge.Merge;
 import net.sf.jsqlparser.statement.refresh.RefreshMaterializedViewStatement;
-import net.sf.jsqlparser.statement.select.AllColumns;
-import net.sf.jsqlparser.statement.select.AllTableColumns;
-import net.sf.jsqlparser.statement.select.GroupByElement;
-import net.sf.jsqlparser.statement.select.GroupByVisitor;
-import net.sf.jsqlparser.statement.select.FromItemVisitor;
-import net.sf.jsqlparser.statement.select.Join;
-import net.sf.jsqlparser.statement.select.LateralSubSelect;
-import net.sf.jsqlparser.statement.select.OrderByElement;
-import net.sf.jsqlparser.statement.select.ParenthesedFromItem;
-import net.sf.jsqlparser.statement.select.ParenthesedSelect;
-import net.sf.jsqlparser.statement.select.PlainSelect;
-import net.sf.jsqlparser.statement.select.Select;
-import net.sf.jsqlparser.statement.select.SelectItem;
-import net.sf.jsqlparser.statement.select.SelectItemVisitor;
-import net.sf.jsqlparser.statement.select.SelectVisitor;
-import net.sf.jsqlparser.statement.select.SetOperationList;
-import net.sf.jsqlparser.statement.select.TableFunction;
-import net.sf.jsqlparser.statement.select.TableStatement;
-import net.sf.jsqlparser.statement.select.Values;
-import net.sf.jsqlparser.statement.select.WithItem;
+import net.sf.jsqlparser.statement.select.*;
 import net.sf.jsqlparser.statement.show.ShowIndexStatement;
 import net.sf.jsqlparser.statement.show.ShowTablesStatement;
 import net.sf.jsqlparser.statement.truncate.Truncate;
 import net.sf.jsqlparser.statement.update.Update;
 import net.sf.jsqlparser.statement.upsert.Upsert;
 
-import static com.metabase.macaw.AstWalker.CallbackKey.*;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 
+import static com.metabase.macaw.AstWalker.CallbackKey.*;
 import static com.metabase.macaw.AstWalker.QueryScopeLabel.*;
 
 /**
@@ -161,8 +90,8 @@ import static com.metabase.macaw.AstWalker.QueryScopeLabel.*;
  * the conventional visitor pattern, providing instead the `callbacks` map. This lets Clojure code use a normal Clojure
  * map and functions to implement the necessary behavior; no `reify` necessary.
  */
-public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, ExpressionVisitor,
-       SelectItemVisitor, StatementVisitor, GroupByVisitor {
+public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, ExpressionVisitor<T>,
+       SelectItemVisitor<T>, StatementVisitor<T>, GroupByVisitor<T> {
 
     public enum CallbackKey {
         ALIAS,
@@ -305,24 +234,26 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
     }
 
     @Override
-    public void visit(Select select) {
+    public <S> T visit(Select select, S context) {
         // No pushContext(SELECT) since it's handled by the ParenthesedSelect and PlainSelect methods
         List<WithItem> withItemsList = select.getWithItemsList();
         if (withItemsList != null && !withItemsList.isEmpty()) {
             for (WithItem withItem : withItemsList) {
-                withItem.accept((SelectVisitor) this);
+                withItem.accept((SelectVisitor) this, context);
             }
         }
-        select.accept((SelectVisitor) this);
+        select.accept((SelectVisitor) this, context);
+        return null;
     }
 
     @Override
-    public void visit(TranscodingFunction transcodingFunction) {
+    public <S> T visit(TranscodingFunction transcodingFunction, S context) {
         transcodingFunction.getExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(TrimFunction trimFunction) {
+    public <S> T visit(TrimFunction trimFunction, S context) {
         if (trimFunction.getExpression() != null) {
             trimFunction.getExpression().accept(this);
         }
@@ -331,23 +262,26 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
             trimFunction.getFromExpression().accept(this);
             popContext(); // FROM
         }
+        return null;
     }
 
     @Override
-    public void visit(RangeExpression rangeExpression) {
+    public <S> T visit(RangeExpression rangeExpression, S context) {
         rangeExpression.getStartExpression().accept(this);
         rangeExpression.getEndExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(WithItem withItem) {
+    public <S> T visit(WithItem withItem, S context) {
         pushContext(WITH_ITEM);
         invokeCallback(PSEUDO_TABLES, withItem.getAlias());
-        withItem.getSelect().accept((SelectVisitor) this);
+        withItem.getSelect().accept((SelectVisitor) this, context);
+        return null;
     }
 
     @Override
-    public void visit(ParenthesedSelect selectBody) {
+    public <S> T visit(ParenthesedSelect selectBody, S context) {
         pushContext(SUB_SELECT);
         Alias alias = selectBody.getAlias();
         if (alias != null) {
@@ -359,22 +293,23 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
                 this.visit(withItem);
             }
         }
-        selectBody.getSelect().accept((SelectVisitor) this);
+        selectBody.getSelect().accept((SelectVisitor<T>) this, context);
         popContext(); // SUB_SELECT
+        return null;
     }
 
     @Override
-    public void visit(PlainSelect plainSelect) {
+    public <S> T visit(PlainSelect plainSelect, S context) {
         pushContext(SELECT);
         List<WithItem> withItemsList = plainSelect.getWithItemsList();
         if (withItemsList != null && !withItemsList.isEmpty()) {
             for (WithItem withItem : withItemsList) {
-                withItem.accept((SelectVisitor) this);
+                withItem.accept((SelectVisitor<T>) this, context);
             }
         }
         if (plainSelect.getSelectItems() != null) {
             for (SelectItem<?> item : plainSelect.getSelectItems()) {
-                item.accept(this);
+                item.accept(this, context);
             }
         }
 
@@ -403,9 +338,10 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
 
         if (plainSelect.getGroupBy() != null) {
             // contextStack handled in visit()
-            plainSelect.getGroupBy().accept(this);
+            plainSelect.getGroupBy().accept(this, context);
         }
         popContext(); // SELECT
+        return null;
     }
 
     @Override
@@ -419,30 +355,34 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
     }
 
     @Override
-    public void visit(Addition addition) {
+    public <S> T visit(Addition addition, S context) {
         visitBinaryExpression(addition);
+        return null;
     }
 
     @Override
-    public void visit(AndExpression andExpression) {
+    public <S> T visit(AndExpression andExpression, S context) {
         visitBinaryExpression(andExpression);
+        return null;
     }
 
     @Override
-    public void visit(Between between) {
+    public <S> T visit(Between between, S context) {
         between.getLeftExpression().accept(this);
         between.getBetweenExpressionStart().accept(this);
         between.getBetweenExpressionEnd().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(OverlapsCondition overlapsCondition) {
+    public <S> T visit(OverlapsCondition overlapsCondition, S context) {
         overlapsCondition.getLeft().accept(this);
         overlapsCondition.getRight().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(Column tableColumn) {
+    public <S> T visit(Column tableColumn, S context) {
         invokeCallback(COLUMN, tableColumn);
 
         Table table = tableColumn.getTable();
@@ -452,176 +392,209 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
             // However, for query rewriting it is necessary.
             visitColumnQualifier(table);
         }
+        return null;
     }
 
     @Override
-    public void visit(Division division) {
+    public <S> T visit(Division division, S context) {
         visitBinaryExpression(division);
+        return null;
     }
 
     @Override
-    public void visit(IntegerDivision division) {
+    public <S> T visit(IntegerDivision division, S context) {
         visitBinaryExpression(division);
+        return null;
     }
 
     @Override
-    public void visit(DoubleValue doubleValue) {
+    public <S> T visit(DoubleValue doubleValue, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(EqualsTo equalsTo) {
+    public <S> T visit(EqualsTo equalsTo, S context) {
         visitBinaryExpression(equalsTo);
+        return null;
     }
 
     @Override
-    public void visit(Function function) {
+    public <S> T visit(Function function, S context) {
         ExpressionList<?> exprList = function.getParameters();
         if (exprList != null) {
             visit(exprList);
         }
+        return null;
     }
 
     @Override
-    public void visit(GreaterThan greaterThan) {
+    public <S> T visit(GreaterThan greaterThan, S context) {
         visitBinaryExpression(greaterThan);
+        return null;
     }
 
     @Override
-    public void visit(GreaterThanEquals greaterThanEquals) {
+    public <S> T visit(GreaterThanEquals greaterThanEquals, S context) {
         visitBinaryExpression(greaterThanEquals);
+        return null;
     }
 
     @Override
-    public void visit(InExpression inExpression) {
+    public <S> T visit(InExpression inExpression, S context) {
         inExpression.getLeftExpression().accept(this);
         inExpression.getRightExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(FullTextSearch fullTextSearch) {
+    public <S> T visit(FullTextSearch fullTextSearch, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(SignedExpression signedExpression) {
+    public <S> T visit(SignedExpression signedExpression, S context) {
         signedExpression.getExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(IsNullExpression isNullExpression) {
+    public <S> T visit(IsNullExpression isNullExpression, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(IsBooleanExpression isBooleanExpression) {
+    public <S> T visit(IsBooleanExpression isBooleanExpression, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(JdbcParameter jdbcParameter) {
+    public <S> T visit(JdbcParameter jdbcParameter, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(LikeExpression likeExpression) {
+    public <S> T visit(LikeExpression likeExpression, S context) {
         visitBinaryExpression(likeExpression);
+        return null;
     }
 
     @Override
-    public void visit(ExistsExpression existsExpression) {
+    public <S> T visit(ExistsExpression existsExpression, S context) {
         existsExpression.getRightExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(MemberOfExpression memberOfExpression) {
+    public <S> T visit(MemberOfExpression memberOfExpression, S context) {
         memberOfExpression.getLeftExpression().accept(this);
         memberOfExpression.getRightExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(LongValue longValue) {
+    public <S> T visit(LongValue longValue, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(MinorThan minorThan) {
+    public <S> T visit(MinorThan minorThan, S context) {
         visitBinaryExpression(minorThan);
+        return null;
     }
 
     @Override
-    public void visit(MinorThanEquals minorThanEquals) {
+    public <S> T visit(MinorThanEquals minorThanEquals, S context) {
         visitBinaryExpression(minorThanEquals);
+        return null;
     }
 
     @Override
-    public void visit(Multiplication multiplication) {
+    public <S> T visit(Multiplication multiplication, S context) {
         visitBinaryExpression(multiplication);
+        return null;
     }
 
     @Override
-    public void visit(NotEqualsTo notEqualsTo) {
+    public <S> T visit(NotEqualsTo notEqualsTo, S context) {
         visitBinaryExpression(notEqualsTo);
+        return null;
     }
 
     @Override
-    public void visit(DoubleAnd doubleAnd) {
+    public <S> T visit(DoubleAnd doubleAnd, S context) {
         visitBinaryExpression(doubleAnd);
+        return null;
     }
 
     @Override
-    public void visit(Contains contains) {
+    public <S> T visit(Contains contains, S context) {
         visitBinaryExpression(contains);
+        return null;
     }
 
     @Override
-    public void visit(ContainedBy containedBy) {
+    public <S> T visit(ContainedBy containedBy, S context) {
         visitBinaryExpression(containedBy);
+        return null;
     }
 
     @Override
-    public void visit(NullValue nullValue) {
+    public <S> T visit(NullValue nullValue, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(OrExpression orExpression) {
+    public <S> T visit(OrExpression orExpression, S context) {
         visitBinaryExpression(orExpression);
+        return null;
     }
 
     @Override
-    public void visit(XorExpression xorExpression) {
+    public <S> T visit(XorExpression xorExpression, S context) {
         visitBinaryExpression(xorExpression);
+        return null;
+    }
+
+//    @Override
+//    public <S> T visit(Parenthesis parenthesis, S context) {
+//        parenthesis.getExpression().accept(this, context);
+//        return null;
+//    }
+
+    @Override
+    public <S> T visit(StringValue stringValue, S context) {
+        return null;
     }
 
     @Override
-    public void visit(Parenthesis parenthesis) {
-        parenthesis.getExpression().accept(this);
-    }
-
-    @Override
-    public void visit(StringValue stringValue) {
-
-    }
-
-    @Override
-    public void visit(Subtraction subtraction) {
+    public <S> T visit(Subtraction subtraction, S context) {
         visitBinaryExpression(subtraction);
+        return null;
     }
 
     @Override
-    public void visit(NotExpression notExpr) {
+    public <S> T visit(NotExpression notExpr, S context) {
         notExpr.getExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(BitwiseRightShift expr) {
+    public <S> T visit(BitwiseRightShift expr, S context) {
         visitBinaryExpression(expr);
+        return null;
     }
 
     @Override
-    public void visit(BitwiseLeftShift expr) {
+    public <S> T visit(BitwiseLeftShift expr, S context) {
         visitBinaryExpression(expr);
+        return null;
     }
 
     public void visitBinaryExpression(BinaryExpression binaryExpression) {
@@ -630,28 +603,29 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
     }
 
     @Override
-    public void visit(ExpressionList<?> expressionList) {
+    public <S> T visit(ExpressionList<?> expressionList, S context) {
         for (Expression expression : expressionList) {
             // The use of a wildcard within a function means "nothing".
             if (!(expression instanceof AllColumns)) {
                 expression.accept(this);
             }
         }
+        return null;
     }
 
     @Override
-    public void visit(DateValue dateValue) {
-
+    public <S> T visit(DateValue dateValue, S context) {
+        return null;
     }
 
     @Override
-    public void visit(TimestampValue timestampValue) {
-
+    public <S> T visit(TimestampValue timestampValue, S context) {
+        return null;
     }
 
     @Override
-    public void visit(TimeValue timeValue) {
-
+    public <S> T visit(TimeValue timeValue, S context) {
+        return null;
     }
 
     /*
@@ -770,16 +744,17 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
     }
 
     @Override
-    public void visit(SetOperationList list) {
+    public <S> T visit(SetOperationList list, S context) {
         List<WithItem> withItemsList = list.getWithItemsList();
         if (withItemsList != null && !withItemsList.isEmpty()) {
             for (WithItem withItem : withItemsList) {
-                withItem.accept((SelectVisitor) this);
+                withItem.accept((SelectVisitor<T>) this, context);
             }
         }
         for (Select selectBody : list.getSelects()) {
-            selectBody.accept((SelectVisitor) this);
+            selectBody.accept((SelectVisitor<T>) this, context);
         }
+        return null;
     }
 
     @Override
@@ -790,8 +765,9 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
     }
 
     @Override
-    public void visit(LateralSubSelect lateralSubSelect) {
-        lateralSubSelect.getSelect().accept((SelectVisitor) this);
+    public <S> T visit(LateralSubSelect lateralSubSelect, S context) {
+        lateralSubSelect.getSelect().accept((SelectVisitor<T>) this, context);
+        return null;
     }
 
     @Override
@@ -919,13 +895,13 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
 
     @SuppressWarnings("deprecation")
     @Override
-    public void visit(Update update) {
+    public <S> T visit(Update update, S context) {
         pushContext(UPDATE);
         invokeCallback(MUTATION_COMMAND, "update");
         visit(update.getTable());
         if (update.getWithItemsList() != null) {
             for (WithItem withItem : update.getWithItemsList()) {
-                withItem.accept((SelectVisitor) this);
+                withItem.accept((SelectVisitor) this, context);
             }
         }
 
@@ -961,118 +937,137 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
             popContext(); // WHERE
         }
         popContext(); // UPDATE
+        return null;
     }
 
     @Override
-    public void visit(Insert insert) {
+    public <S> T visit(Insert insert, S context) {
         pushContext(INSERT);
         invokeCallback(MUTATION_COMMAND, "insert");
         visit(insert.getTable());
         if (insert.getWithItemsList() != null) {
             for (WithItem withItem : insert.getWithItemsList()) {
-                withItem.accept((SelectVisitor) this);
+                withItem.accept((SelectVisitor) this, context);
             }
         }
         if (insert.getSelect() != null) {
             visit(insert.getSelect());
         }
         popContext(); // INSERT
+        return null;
     }
 
-    public void visit(Analyze analyze) {
+    public <S> T visit(Analyze analyze, S context) {
         visit(analyze.getTable());
+        return null;
     }
 
     @Override
-    public void visit(Drop drop) {
+    public <S> T visit(Drop drop, S context) {
         invokeCallback(MUTATION_COMMAND, "drop");
         visit(drop.getName());
+        return null;
     }
 
     @Override
-    public void visit(Truncate truncate) {
+    public <S> T visit(Truncate truncate, S context) {
         invokeCallback(MUTATION_COMMAND, "truncate");
         visit(truncate.getTable());
+        return null;
     }
 
     @Override
-    public void visit(CreateIndex createIndex) {
+    public <S> T visit(CreateIndex createIndex, S context) {
         invokeCallback(MUTATION_COMMAND, "create-index");
+        return null;
     }
 
     @Override
-    public void visit(CreateSchema aThis) {
+    public <S> T visit(CreateSchema aThis, S context) {
         invokeCallback(MUTATION_COMMAND, "create-schema");
+        return null;
     }
 
     @Override
-    public void visit(CreateTable create) {
+    public <S> T visit(CreateTable create, S context) {
         invokeCallback(MUTATION_COMMAND, "create-table");
         visit(create.getTable());
         if (create.getSelect() != null) {
             create.getSelect().accept((SelectVisitor) this);
         }
+        return null;
     }
 
     @Override
-    public void visit(CreateView createView) {
+    public <S> T visit(CreateView createView, S context) {
         invokeCallback(MUTATION_COMMAND, "create-view");
+        return null;
     }
 
     @Override
-    public void visit(Alter alter) {
+    public <S> T visit(Alter alter, S context) {
         invokeCallback(MUTATION_COMMAND, "alter-table");
+        return null;
     }
 
     @Override
-    public void visit(Statements stmts) {
-        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    public <S> T visit(Statements stmts, S context) {
+            throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+        return null;
     }
 
     @Override
-    public void visit(Execute execute) {
-        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    public <S> T visit(Execute execute, S context) {
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        return null;
     }
 
     @Override
-    public void visit(SetStatement set) {
-        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    public <S> T visit(SetStatement set, S context) {
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        return null;
     }
 
     @Override
-    public void visit(ResetStatement reset) {
-        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    public <S> T visit(ResetStatement reset, S context) {
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        return null;
     }
 
     @Override
-    public void visit(ShowColumnsStatement set) {
-        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    public <S> T visit(ShowColumnsStatement set, S context) {
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        return null;
     }
 
     @Override
-    public void visit(ShowIndexStatement showIndex) {
-        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    public <S> T visit(ShowIndexStatement showIndex, S context) {
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        return null;
     }
 
     @Override
-    public void visit(RowConstructor<?> rowConstructor) {
+    public <S> T visit(RowConstructor<?> rowConstructor, S context) {
         for (Expression expr : rowConstructor) {
             expr.accept(this);
         }
+        return null;
     }
 
     @Override
-    public void visit(RowGetExpression rowGetExpression) {
+    public <S> T visit(RowGetExpression rowGetExpression, S context) {
         rowGetExpression.getExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(HexValue hexValue) {
+    public <S> T visit(HexValue hexValue, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(Merge merge) {
+    public <S> T visit(Merge merge, S context) {
         visit(merge.getTable());
         if (merge.getWithItemsList() != null) {
             for (WithItem withItem : merge.getWithItemsList()) {
@@ -1085,45 +1080,51 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
             merge.getFromItem().accept(this);
             popContext(); // FROM
         }
+        return null;
     }
 
     @Override
-    public void visit(OracleHint hint) {
+    public <S> T visit(OracleHint hint, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(TableFunction tableFunction) {
+    public <S> T visit(TableFunction tableFunction, S context) {
         visit(tableFunction.getFunction());
+        return null;
     }
 
     @Override
-    public void visit(AlterView alterView) {
+    public <S> T visit(AlterView alterView, S context) {
         invokeCallback(MUTATION_COMMAND, "alter-view");
+        return null;
     }
 
     @Override
-    public void visit(RefreshMaterializedViewStatement materializedView) {
+    public <S> T visit(RefreshMaterializedViewStatement materializedView, S context) {
         visit(materializedView.getView());
+        return null;
     }
 
     @Override
-    public void visit(TimeKeyExpression timeKeyExpression) {
-
+    public <S> T visit(TimeKeyExpression timeKeyExpression, S context) {
+        return null;
     }
 
     @Override
-    public void visit(DateTimeLiteralExpression literal) {
-
+    public <S> T visit(DateTimeLiteralExpression literal, S context) {
+        return null;
     }
 
     @Override
-    public void visit(Commit commit) {
+    public <S> T visit(Commit commit, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(Upsert upsert) {
+    public <S> T visit(Upsert upsert, S context) {
         visit(upsert.getTable());
         if (upsert.getExpressions() != null) {
             upsert.getExpressions().accept(this);
@@ -1131,22 +1132,24 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
         if (upsert.getSelect() != null) {
             visit(upsert.getSelect());
         }
+        return null;
     }
 
     @Override
-    public void visit(UseStatement use) {
-
+    public <S> T visit(UseStatement use, S context) {
+        return null;
     }
 
     @Override
-    public void visit(ParenthesedFromItem parenthesis) {
+    public <S> T visit(ParenthesedFromItem parenthesis, S context) {
         parenthesis.getFromItem().accept(this);
         // support join keyword in fromItem
         visitJoins(parenthesis.getJoins());
+        return null;
     }
 
     @Override
-    public void visit(GroupByElement element) {
+    public <S> T visit(GroupByElement element, S context) {
         pushContext(GROUP_BY);
         element.getGroupByExpressionList().accept(this);
         for (ExpressionList<?> exprList : element.getGroupingSets()) {
@@ -1178,14 +1181,15 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
     }
 
     @Override
-    public void visit(Block block) {
+    public <S> T visit(Block block, S context) {
         if (block.getStatements() != null) {
             visit(block.getStatements());
         }
+        return null;
     }
 
     @Override
-    public void visit(Comment comment) {
+    public <S> T visit(Comment comment, S context) {
         if (comment.getTable() != null) {
             visit(comment.getTable());
         }
@@ -1195,57 +1199,67 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
                 visit(table);
             }
         }
+        return null;
     }
 
     @Override
-    public void visit(Values values) {
+    public <S> T visit(Values values, S context) {
         values.getExpressions().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(DescribeStatement describe) {
+    public <S> T visit(DescribeStatement describe, S context) {
         describe.getTable().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(ExplainStatement explain) {
+    public <S> T visit(ExplainStatement explain, S context) {
         if (explain.getStatement() != null) {
             explain.getStatement().accept((StatementVisitor) this);
         }
+        return null;
     }
 
     @Override
-    public void visit(NextValExpression nextVal) {
+    public <S> T visit(NextValExpression nextVal, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(CollateExpression col) {
+    public <S> T visit(CollateExpression col, S context) {
         col.getLeftExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(ShowStatement aThis) {
+    public <S> T visit(ShowStatement aThis, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(SimilarToExpression expr) {
+    public <S> T visit(SimilarToExpression expr, S context) {
         visitBinaryExpression(expr);
+        return null;
     }
 
     @Override
-    public void visit(DeclareStatement aThis) {
+    public <S> T visit(DeclareStatement aThis, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(Grant grant) {
+    public <S> T visit(Grant grant, S context) {
         invokeCallback(MUTATION_COMMAND, "grant");
+        return null;
     }
 
     @Override
-    public void visit(ArrayExpression array) {
+    public <S> T visit(ArrayExpression array, S context) {
         array.getObjExpression().accept(this);
         if (array.getStartIndexExpression() != null) {
             array.getIndexExpression().accept(this);
@@ -1256,82 +1270,97 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
         if (array.getStopIndexExpression() != null) {
             array.getStopIndexExpression().accept(this);
         }
+        return null;
     }
 
     @Override
-    public void visit(ArrayConstructor array) {
+    public <S> T visit(ArrayConstructor array, S context) {
         for (Expression expression : array.getExpressions()) {
             expression.accept(this);
         }
+        return null;
     }
 
     @Override
-    public void visit(CreateSequence createSequence) {
+    public <S> T visit(CreateSequence createSequence, S context) {
         invokeCallback(MUTATION_COMMAND, "create-sequence");
+        return null;
     }
 
     @Override
-    public void visit(AlterSequence alterSequence) {
+    public <S> T visit(AlterSequence alterSequence, S context) {
         invokeCallback(MUTATION_COMMAND, "alter-sequence");
+        return null;
     }
 
     @Override
-    public void visit(CreateFunctionalStatement createFunctionalStatement) {
+    public <S> T visit(CreateFunctionalStatement createFunctionalStatement, S context) {
         invokeCallback(MUTATION_COMMAND, "create-function");
+        return null;
     }
 
     @Override
-    public void visit(ShowTablesStatement showTables) {
+    public <S> T visit(ShowTablesStatement showTables, S context) {
         throw new UnsupportedOperationException(
                 "Reading from a ShowTablesStatement is not supported");
+        return null;
     }
 
     @Override
-    public void visit(TSQLLeftJoin tsqlLeftJoin) {
+    public <S> T visit(TSQLLeftJoin tsqlLeftJoin, S context) {
         visitBinaryExpression(tsqlLeftJoin);
+        return null;
     }
 
     @Override
-    public void visit(TSQLRightJoin tsqlRightJoin) {
+    public <S> T visit(TSQLRightJoin tsqlRightJoin, S context) {
         visitBinaryExpression(tsqlRightJoin);
+        return null;
     }
 
     @Override
-    public void visit(VariableAssignment var) {
+    public <S> T visit(VariableAssignment var, S context) {
         var.getVariable().accept(this);
         var.getExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(XMLSerializeExpr aThis) {
+    public <S> T visit(XMLSerializeExpr aThis, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(CreateSynonym createSynonym) {
+    public <S> T visit(CreateSynonym createSynonym, S context) {
         invokeCallback(MUTATION_COMMAND, "create-synonym");
+        return null;
     }
 
     @Override
-    public void visit(TimezoneExpression aThis) {
+    public <S> T visit(TimezoneExpression aThis, S context) {
         aThis.getLeftExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(SavepointStatement savepointStatement) {}
+    return null;
+    public <S> T visit(SavepointStatement savepointStatement, S context) {}
 
     @Override
-    public void visit(RollbackStatement rollbackStatement) {
+    public <S> T visit(RollbackStatement rollbackStatement, S context) {
 
+        return null;
     }
 
     @Override
-    public void visit(AlterSession alterSession) {
+    public <S> T visit(AlterSession alterSession, S context) {
         invokeCallback(MUTATION_COMMAND, "alter-session");
+        return null;
     }
 
     @Override
-    public void visit(JsonAggregateFunction expression) {
+    public <S> T visit(JsonAggregateFunction expression, S context) {
         Expression expr = expression.getExpression();
         if (expr != null) {
             expr.accept(this);
@@ -1341,21 +1370,24 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
         if (expr != null) {
             expr.accept(this);
         }
+        return null;
     }
 
     @Override
-    public void visit(JsonFunction expression) {
+    public <S> T visit(JsonFunction expression, S context) {
         for (JsonFunctionExpression expr : expression.getExpressions()) {
             expr.getExpression().accept(this);
         }
+        return null;
     }
 
     @Override
-    public void visit(ConnectByRootOperator connectByRootOperator) {
+    public <S> T visit(ConnectByRootOperator connectByRootOperator, S context) {
         connectByRootOperator.getColumn().accept(this);
+        return null;
     }
 
-    public void visit(IfElseStatement ifElseStatement) {
+    public <S> T visit(IfElseStatement ifElseStatement, S context) {
         pushContext(IF);
         ifElseStatement.getIfStatement().accept(this);
         popContext(); // IF
@@ -1364,40 +1396,47 @@ public class AstWalker<Acc> implements SelectVisitor, FromItemVisitor, Expressio
             ifElseStatement.getElseStatement().accept(this);
             popContext(); // ELSE
         }
+        return null;
     }
 
-    public void visit(OracleNamedFunctionParameter oracleNamedFunctionParameter) {
+    public <S> T visit(OracleNamedFunctionParameter oracleNamedFunctionParameter, S context) {
         oracleNamedFunctionParameter.getExpression().accept(this);
+        return null;
     }
 
     @Override
-    public void visit(RenameTableStatement renameTableStatement) {
+    public <S> T visit(RenameTableStatement renameTableStatement, S context) {
         invokeCallback(MUTATION_COMMAND, "rename-table");
         for (Map.Entry<Table, Table> e : renameTableStatement.getTableNames()) {
             e.getKey().accept(this);
             e.getValue().accept(this);
         }
+        return null;
     }
 
     @Override
-    public void visit(PurgeStatement purgeStatement) {
+    public <S> T visit(PurgeStatement purgeStatement, S context) {
         invokeCallback(MUTATION_COMMAND, "purge");
         if (purgeStatement.getPurgeObjectType() == PurgeObjectType.TABLE) {
             ((Table) purgeStatement.getObject()).accept(this);
         }
+        return null;
     }
 
     @Override
-    public void visit(AlterSystemStatement alterSystemStatement) {
+    public <S> T visit(AlterSystemStatement alterSystemStatement, S context) {
         invokeCallback(MUTATION_COMMAND, "alter-system");
+        return null;
     }
 
     @Override
-    public void visit(UnsupportedStatement unsupportedStatement) {
+    public <S> T visit(UnsupportedStatement unsupportedStatement, S context) {
+        return null;
     }
 
     @Override
-    public void visit(GeometryDistance geometryDistance) {
+    public <S> T visit(GeometryDistance geometryDistance, S context) {
         visitBinaryExpression(geometryDistance);
+        return null;
     }
 }

--- a/java/com/metabase/macaw/AstWalker.java
+++ b/java/com/metabase/macaw/AstWalker.java
@@ -48,10 +48,6 @@ import net.sf.jsqlparser.statement.truncate.Truncate;
 import net.sf.jsqlparser.statement.update.Update;
 import net.sf.jsqlparser.statement.upsert.Upsert;
 
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-
 import static com.metabase.macaw.AstWalker.CallbackKey.*;
 import static com.metabase.macaw.AstWalker.QueryScopeLabel.*;
 
@@ -247,9 +243,21 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(Select select) {
+        // We need to override all these default methods, as they are inherited from multiple interfaces.
+        // Since their implementation is consistent, it doesn't matter which version we pick.
+        ExpressionVisitor.super.visit(select);
+    }
+
+    @Override
     public <S> T visit(TranscodingFunction transcodingFunction, S context) {
         transcodingFunction.getExpression().accept(this);
         return null;
+    }
+
+    @Override
+    public void visit(TranscodingFunction transcodingFunction) {
+        ExpressionVisitor.super.visit(transcodingFunction);
     }
 
     @Override
@@ -266,10 +274,20 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(TrimFunction trimFunction) {
+        ExpressionVisitor.super.visit(trimFunction);
+    }
+
+    @Override
     public <S> T visit(RangeExpression rangeExpression, S context) {
         rangeExpression.getStartExpression().accept(this);
         rangeExpression.getEndExpression().accept(this);
         return null;
+    }
+
+    @Override
+    public void visit(RangeExpression rangeExpression) {
+        ExpressionVisitor.super.visit(rangeExpression);
     }
 
     @Override
@@ -278,6 +296,11 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
         invokeCallback(PSEUDO_TABLES, withItem.getAlias());
         withItem.getSelect().accept((SelectVisitor) this, context);
         return null;
+    }
+
+    @Override
+    public void visit(WithItem withItem) {
+        SelectVisitor.super.visit(withItem);
     }
 
     @Override
@@ -296,6 +319,11 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
         selectBody.getSelect().accept((SelectVisitor<T>) this, context);
         popContext(); // SUB_SELECT
         return null;
+    }
+
+    @Override
+    public void visit(ParenthesedSelect parenthesedSelect) {
+        SelectVisitor.super.visit(parenthesedSelect);
     }
 
     @Override
@@ -345,8 +373,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
-    public void visit(Table table) {
+    public void visit(PlainSelect plainSelect) {
+        SelectVisitor.super.visit(plainSelect);
+    }
+
+    @Override
+    public <S> T visit(Table table, S context) {
         invokeCallback(TABLE, table);
+        return null;
+    }
+
+    @Override
+    public void visit(Table tableName) {
+        FromItemVisitor.super.visit(tableName);
     }
 
     // Could be an alias, could be a real table
@@ -356,14 +395,24 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
 
     @Override
     public <S> T visit(Addition addition, S context) {
-        visitBinaryExpression(addition);
+        visitBinaryExpression(addition, context);
         return null;
     }
 
     @Override
+    public void visit(Addition addition) {
+        ExpressionVisitor.super.visit(addition);
+    }
+
+    @Override
     public <S> T visit(AndExpression andExpression, S context) {
-        visitBinaryExpression(andExpression);
+        visitBinaryExpression(andExpression, context);
         return null;
+    }
+
+    @Override
+    public void visit(AndExpression andExpression) {
+        ExpressionVisitor.super.visit(andExpression);
     }
 
     @Override
@@ -375,10 +424,20 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(Between between) {
+        ExpressionVisitor.super.visit(between);
+    }
+
+    @Override
     public <S> T visit(OverlapsCondition overlapsCondition, S context) {
         overlapsCondition.getLeft().accept(this);
         overlapsCondition.getRight().accept(this);
         return null;
+    }
+
+    @Override
+    public void visit(OverlapsCondition overlapsCondition) {
+        ExpressionVisitor.super.visit(overlapsCondition);
     }
 
     @Override
@@ -396,15 +455,30 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(Column column) {
+        ExpressionVisitor.super.visit(column);
+    }
+
+    @Override
     public <S> T visit(Division division, S context) {
-        visitBinaryExpression(division);
+        visitBinaryExpression(division, context);
         return null;
     }
 
     @Override
+    public void visit(Division division) {
+        ExpressionVisitor.super.visit(division);
+    }
+
+    @Override
     public <S> T visit(IntegerDivision division, S context) {
-        visitBinaryExpression(division);
+        visitBinaryExpression(division, context);
         return null;
+    }
+
+    @Override
+    public void visit(IntegerDivision integerDivision) {
+        ExpressionVisitor.super.visit(integerDivision);
     }
 
     @Override
@@ -414,9 +488,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(DoubleValue doubleValue) {
+        ExpressionVisitor.super.visit(doubleValue);
+    }
+
+    @Override
     public <S> T visit(EqualsTo equalsTo, S context) {
-        visitBinaryExpression(equalsTo);
+        visitBinaryExpression(equalsTo, context);
         return null;
+    }
+
+    @Override
+    public void visit(EqualsTo equalsTo) {
+        ExpressionVisitor.super.visit(equalsTo);
     }
 
     @Override
@@ -429,15 +513,30 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(Function function) {
+        ExpressionVisitor.super.visit(function);
+    }
+
+    @Override
     public <S> T visit(GreaterThan greaterThan, S context) {
-        visitBinaryExpression(greaterThan);
+        visitBinaryExpression(greaterThan, context);
         return null;
     }
 
     @Override
+    public void visit(GreaterThan greaterThan) {
+        ExpressionVisitor.super.visit(greaterThan);
+    }
+
+    @Override
     public <S> T visit(GreaterThanEquals greaterThanEquals, S context) {
-        visitBinaryExpression(greaterThanEquals);
+        visitBinaryExpression(greaterThanEquals, context);
         return null;
+    }
+
+    @Override
+    public void visit(GreaterThanEquals greaterThanEquals) {
+        ExpressionVisitor.super.visit(greaterThanEquals);
     }
 
     @Override
@@ -448,9 +547,41 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(InExpression inExpression) {
+        ExpressionVisitor.super.visit(inExpression);
+    }
+
+    @Override
+    public <S> T visit(IncludesExpression includesExpression, S s) {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public void visit(IncludesExpression includesExpression) {
+        ExpressionVisitor.super.visit(includesExpression);
+    }
+
+    @Override
+    public <S> T visit(ExcludesExpression excludesExpression, S s) {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public void visit(ExcludesExpression excludesExpression) {
+        ExpressionVisitor.super.visit(excludesExpression);
+    }
+
+    @Override
     public <S> T visit(FullTextSearch fullTextSearch, S context) {
 
         return null;
+    }
+
+    @Override
+    public void visit(FullTextSearch fullTextSearch) {
+        ExpressionVisitor.super.visit(fullTextSearch);
     }
 
     @Override
@@ -460,9 +591,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(SignedExpression signedExpression) {
+        ExpressionVisitor.super.visit(signedExpression);
+    }
+
+    @Override
     public <S> T visit(IsNullExpression isNullExpression, S context) {
 
         return null;
+    }
+
+    @Override
+    public void visit(IsNullExpression isNullExpression) {
+        ExpressionVisitor.super.visit(isNullExpression);
     }
 
     @Override
@@ -472,21 +613,41 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(IsBooleanExpression isBooleanExpression) {
+        ExpressionVisitor.super.visit(isBooleanExpression);
+    }
+
+    @Override
     public <S> T visit(JdbcParameter jdbcParameter, S context) {
 
         return null;
     }
 
     @Override
+    public void visit(JdbcParameter jdbcParameter) {
+        ExpressionVisitor.super.visit(jdbcParameter);
+    }
+
+    @Override
     public <S> T visit(LikeExpression likeExpression, S context) {
-        visitBinaryExpression(likeExpression);
+        visitBinaryExpression(likeExpression, context);
         return null;
+    }
+
+    @Override
+    public void visit(LikeExpression likeExpression) {
+        ExpressionVisitor.super.visit(likeExpression);
     }
 
     @Override
     public <S> T visit(ExistsExpression existsExpression, S context) {
         existsExpression.getRightExpression().accept(this);
         return null;
+    }
+
+    @Override
+    public void visit(ExistsExpression existsExpression) {
+        ExpressionVisitor.super.visit(existsExpression);
     }
 
     @Override
@@ -497,51 +658,96 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(MemberOfExpression memberOfExpression) {
+        ExpressionVisitor.super.visit(memberOfExpression);
+    }
+
+    @Override
     public <S> T visit(LongValue longValue, S context) {
 
         return null;
     }
 
     @Override
+    public void visit(LongValue longValue) {
+        ExpressionVisitor.super.visit(longValue);
+    }
+
+    @Override
     public <S> T visit(MinorThan minorThan, S context) {
-        visitBinaryExpression(minorThan);
+        visitBinaryExpression(minorThan, context);
         return null;
+    }
+
+    @Override
+    public void visit(MinorThan minorThan) {
+        ExpressionVisitor.super.visit(minorThan);
     }
 
     @Override
     public <S> T visit(MinorThanEquals minorThanEquals, S context) {
-        visitBinaryExpression(minorThanEquals);
+        visitBinaryExpression(minorThanEquals, context);
         return null;
+    }
+
+    @Override
+    public void visit(MinorThanEquals minorThanEquals) {
+        ExpressionVisitor.super.visit(minorThanEquals);
     }
 
     @Override
     public <S> T visit(Multiplication multiplication, S context) {
-        visitBinaryExpression(multiplication);
+        visitBinaryExpression(multiplication, context);
         return null;
+    }
+
+    @Override
+    public void visit(Multiplication multiplication) {
+        ExpressionVisitor.super.visit(multiplication);
     }
 
     @Override
     public <S> T visit(NotEqualsTo notEqualsTo, S context) {
-        visitBinaryExpression(notEqualsTo);
+        visitBinaryExpression(notEqualsTo, context);
         return null;
+    }
+
+    @Override
+    public void visit(NotEqualsTo notEqualsTo) {
+        ExpressionVisitor.super.visit(notEqualsTo);
     }
 
     @Override
     public <S> T visit(DoubleAnd doubleAnd, S context) {
-        visitBinaryExpression(doubleAnd);
+        visitBinaryExpression(doubleAnd, context);
         return null;
+    }
+
+    @Override
+    public void visit(DoubleAnd doubleAnd) {
+        ExpressionVisitor.super.visit(doubleAnd);
     }
 
     @Override
     public <S> T visit(Contains contains, S context) {
-        visitBinaryExpression(contains);
+        visitBinaryExpression(contains, context);
         return null;
     }
 
     @Override
+    public void visit(Contains contains) {
+        ExpressionVisitor.super.visit(contains);
+    }
+
+    @Override
     public <S> T visit(ContainedBy containedBy, S context) {
-        visitBinaryExpression(containedBy);
+        visitBinaryExpression(containedBy, context);
         return null;
+    }
+
+    @Override
+    public void visit(ContainedBy containedBy) {
+        ExpressionVisitor.super.visit(containedBy);
     }
 
     @Override
@@ -551,22 +757,31 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(NullValue nullValue) {
+        ExpressionVisitor.super.visit(nullValue);
+    }
+
+    @Override
     public <S> T visit(OrExpression orExpression, S context) {
-        visitBinaryExpression(orExpression);
+        visitBinaryExpression(orExpression, context);
         return null;
     }
 
     @Override
+    public void visit(OrExpression orExpression) {
+        ExpressionVisitor.super.visit(orExpression);
+    }
+
+    @Override
     public <S> T visit(XorExpression xorExpression, S context) {
-        visitBinaryExpression(xorExpression);
+        visitBinaryExpression(xorExpression, context);
         return null;
     }
 
-//    @Override
-//    public <S> T visit(Parenthesis parenthesis, S context) {
-//        parenthesis.getExpression().accept(this, context);
-//        return null;
-//    }
+    @Override
+    public void visit(XorExpression xorExpression) {
+        ExpressionVisitor.super.visit(xorExpression);
+    }
 
     @Override
     public <S> T visit(StringValue stringValue, S context) {
@@ -574,9 +789,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(StringValue stringValue) {
+        ExpressionVisitor.super.visit(stringValue);
+    }
+
+    @Override
     public <S> T visit(Subtraction subtraction, S context) {
-        visitBinaryExpression(subtraction);
+        visitBinaryExpression(subtraction, context);
         return null;
+    }
+
+    @Override
+    public void visit(Subtraction subtraction) {
+        ExpressionVisitor.super.visit(subtraction);
     }
 
     @Override
@@ -586,20 +811,36 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(NotExpression notExpression) {
+        ExpressionVisitor.super.visit(notExpression);
+    }
+
+    @Override
     public <S> T visit(BitwiseRightShift expr, S context) {
-        visitBinaryExpression(expr);
+        visitBinaryExpression(expr, context);
         return null;
     }
 
     @Override
+    public void visit(BitwiseRightShift bitwiseRightShift) {
+        ExpressionVisitor.super.visit(bitwiseRightShift);
+    }
+
+    @Override
     public <S> T visit(BitwiseLeftShift expr, S context) {
-        visitBinaryExpression(expr);
+        visitBinaryExpression(expr, context);
         return null;
     }
 
-    public void visitBinaryExpression(BinaryExpression binaryExpression) {
+    @Override
+    public void visit(BitwiseLeftShift bitwiseLeftShift) {
+        ExpressionVisitor.super.visit(bitwiseLeftShift);
+    }
+
+    public <S> T visitBinaryExpression(BinaryExpression binaryExpression, S context) {
         binaryExpression.getLeftExpression().accept(this);
         binaryExpression.getRightExpression().accept(this);
+        return null;
     }
 
     @Override
@@ -614,8 +855,18 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(ExpressionList<? extends Expression> expressionList) {
+        ExpressionVisitor.super.visit(expressionList);
+    }
+
+    @Override
     public <S> T visit(DateValue dateValue, S context) {
         return null;
+    }
+
+    @Override
+    public void visit(DateValue dateValue) {
+        ExpressionVisitor.super.visit(dateValue);
     }
 
     @Override
@@ -624,8 +875,18 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(TimestampValue timestampValue) {
+        ExpressionVisitor.super.visit(timestampValue);
+    }
+
+    @Override
     public <S> T visit(TimeValue timeValue, S context) {
         return null;
+    }
+
+    @Override
+    public void visit(TimeValue timeValue) {
+        ExpressionVisitor.super.visit(timeValue);
     }
 
     /*
@@ -635,7 +896,7 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
      * CaseExpression)
      */
     @Override
-    public void visit(CaseExpression caseExpression) {
+    public <S> T visit(CaseExpression caseExpression, S context) {
         if (caseExpression.getSwitchExpression() != null) {
             caseExpression.getSwitchExpression().accept(this);
         }
@@ -647,6 +908,12 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
         if (caseExpression.getElseExpression() != null) {
             caseExpression.getElseExpression().accept(this);
         }
+        return null;
+    }
+
+    @Override
+    public void visit(CaseExpression caseExpression) {
+        ExpressionVisitor.super.visit(caseExpression);
     }
 
     /*
@@ -656,57 +923,111 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
      * net.sf.jsqlparser.expression.ExpressionVisitor#visit(net.sf.jsqlparser.expression.WhenClause)
      */
     @Override
-    public void visit(WhenClause whenClause) {
+    public <S> T visit(WhenClause whenClause, S context) {
         if (whenClause.getWhenExpression() != null) {
             whenClause.getWhenExpression().accept(this);
         }
         if (whenClause.getThenExpression() != null) {
             whenClause.getThenExpression().accept(this);
         }
+        return null;
+    }
+
+    @Override
+    public void visit(WhenClause whenClause) {
+        ExpressionVisitor.super.visit(whenClause);
+    }
+
+    @Override
+    public <S> T visit(AnyComparisonExpression anyComparisonExpression, S context) {
+        anyComparisonExpression.getSelect().accept((ExpressionVisitor) this);
+        return null;
     }
 
     @Override
     public void visit(AnyComparisonExpression anyComparisonExpression) {
-        anyComparisonExpression.getSelect().accept((ExpressionVisitor) this);
+        ExpressionVisitor.super.visit(anyComparisonExpression);
+    }
+
+    @Override
+    public <S> T visit(Concat concat, S context) {
+        visitBinaryExpression(concat, context);
+        return null;
     }
 
     @Override
     public void visit(Concat concat) {
-        visitBinaryExpression(concat);
+        ExpressionVisitor.super.visit(concat);
+    }
+
+    @Override
+    public <S> T visit(Matches matches, S context) {
+        visitBinaryExpression(matches, context);
+        return null;
     }
 
     @Override
     public void visit(Matches matches) {
-        visitBinaryExpression(matches);
+        ExpressionVisitor.super.visit(matches);
+    }
+
+    @Override
+    public <S> T visit(BitwiseAnd bitwiseAnd, S context) {
+        visitBinaryExpression(bitwiseAnd, context);
+        return null;
     }
 
     @Override
     public void visit(BitwiseAnd bitwiseAnd) {
-        visitBinaryExpression(bitwiseAnd);
+        ExpressionVisitor.super.visit(bitwiseAnd);
+    }
+
+    @Override
+    public <S> T visit(BitwiseOr bitwiseOr, S context) {
+        visitBinaryExpression(bitwiseOr, context);
+        return null;
     }
 
     @Override
     public void visit(BitwiseOr bitwiseOr) {
-        visitBinaryExpression(bitwiseOr);
+        ExpressionVisitor.super.visit(bitwiseOr);
+    }
+
+    @Override
+    public <S> T visit(BitwiseXor bitwiseXor, S context) {
+        visitBinaryExpression(bitwiseXor, context);
+        return null;
     }
 
     @Override
     public void visit(BitwiseXor bitwiseXor) {
-        visitBinaryExpression(bitwiseXor);
+        ExpressionVisitor.super.visit(bitwiseXor);
     }
 
     @Override
-    public void visit(CastExpression cast) {
+    public <S> T visit(CastExpression cast, S context) {
         cast.getLeftExpression().accept(this);
+        return null;
+    }
+
+    @Override
+    public void visit(CastExpression castExpression) {
+        ExpressionVisitor.super.visit(castExpression);
+    }
+
+    @Override
+    public <S> T visit(Modulo modulo, S context) {
+        visitBinaryExpression(modulo, context);
+        return null;
     }
 
     @Override
     public void visit(Modulo modulo) {
-        visitBinaryExpression(modulo);
+        ExpressionVisitor.super.visit(modulo);
     }
 
     @Override
-    public void visit(AnalyticExpression analytic) {
+    public <S> T visit(AnalyticExpression analytic, S context) {
         maybeAcceptThis(analytic.getExpression());
         maybeAcceptThis(analytic.getDefaultValue());
         maybeAcceptThis(analytic.getOffset());
@@ -729,6 +1050,12 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
                 maybeAcceptThis(offset.getExpression());
             }
         }
+        return null;
+    }
+
+    @Override
+    public void visit(AnalyticExpression analyticExpression) {
+        ExpressionVisitor.super.visit(analyticExpression);
     }
 
     private void maybeAcceptThis(Expression expression) {
@@ -758,10 +1085,21 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
-    public void visit(ExtractExpression eexpr) {
+    public void visit(SetOperationList setOpList) {
+        SelectVisitor.super.visit(setOpList);
+    }
+
+    @Override
+    public <S> T visit(ExtractExpression eexpr, S context) {
         if (eexpr.getExpression() != null) {
             eexpr.getExpression().accept(this);
         }
+        return null;
+    }
+
+    @Override
+    public void visit(ExtractExpression extractExpression) {
+        ExpressionVisitor.super.visit(extractExpression);
     }
 
     @Override
@@ -771,24 +1109,47 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
-    public void visit(TableStatement tableStatement) {
-        tableStatement.getTable().accept(this);
+    public void visit(LateralSubSelect lateralSubSelect) {
+        SelectVisitor.super.visit(lateralSubSelect);
     }
 
     @Override
-    public void visit(IntervalExpression iexpr) {
+    public <S> T visit(TableStatement tableStatement, S context) {
+        tableStatement.getTable().accept(this);
+        return null;
+    }
+
+    @Override
+    public void visit(TableStatement tableStatement) {
+        SelectVisitor.super.visit(tableStatement);
+    }
+
+    @Override
+    public <S> T visit(IntervalExpression iexpr, S context) {
         if (iexpr.getExpression() != null) {
             iexpr.getExpression().accept(this);
         }
+        return null;
+    }
+
+    @Override
+    public void visit(IntervalExpression intervalExpression) {
+        ExpressionVisitor.super.visit(intervalExpression);
+    }
+
+    @Override
+    public <S> T visit(JdbcNamedParameter jdbcNamedParameter, S context) {
+
+        return null;
     }
 
     @Override
     public void visit(JdbcNamedParameter jdbcNamedParameter) {
-
+        ExpressionVisitor.super.visit(jdbcNamedParameter);
     }
 
     @Override
-    public void visit(OracleHierarchicalExpression oexpr) {
+    public <S> T visit(OracleHierarchicalExpression oexpr, S context) {
         if (oexpr.getStartExpression() != null) {
             oexpr.getStartExpression().accept(this);
         }
@@ -796,47 +1157,95 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
         if (oexpr.getConnectExpression() != null) {
             oexpr.getConnectExpression().accept(this);
         }
+        return null;
     }
 
     @Override
-    public void visit(RegExpMatchOperator rexpr) {
-        visitBinaryExpression(rexpr);
+    public void visit(OracleHierarchicalExpression hierarchicalExpression) {
+        ExpressionVisitor.super.visit(hierarchicalExpression);
     }
 
     @Override
-    public void visit(JsonExpression jsonExpr) {
+    public <S> T visit(RegExpMatchOperator rexpr, S context) {
+        visitBinaryExpression(rexpr, context);
+        return null;
+    }
+
+    @Override
+    public void visit(RegExpMatchOperator regExpMatchOperator) {
+        ExpressionVisitor.super.visit(regExpMatchOperator);
+    }
+
+    @Override
+    public <S> T visit(JsonExpression jsonExpr, S context) {
         if (jsonExpr.getExpression() != null) {
             jsonExpr.getExpression().accept(this);
         }
+        return null;
     }
 
     @Override
-    public void visit(JsonOperator jsonExpr) {
-        visitBinaryExpression(jsonExpr);
+    public void visit(JsonExpression jsonExpression) {
+        ExpressionVisitor.super.visit(jsonExpression);
+    }
+
+    @Override
+    public <S> T visit(JsonOperator jsonExpr, S context) {
+        visitBinaryExpression(jsonExpr, context);
+        return null;
+    }
+
+    @Override
+    public void visit(JsonOperator jsonOperator) {
+        ExpressionVisitor.super.visit(jsonOperator);
+    }
+
+    @Override
+    public <S> T visit(AllColumns allColumns, S context) {
+        invokeCallback(ALL_COLUMNS, allColumns);
+        return null;
     }
 
     @Override
     public void visit(AllColumns allColumns) {
-        invokeCallback(ALL_COLUMNS, allColumns);
+        ExpressionVisitor.super.visit(allColumns);
+    }
+
+    @Override
+    public <S> T visit(AllTableColumns allTableColumns, S context) {
+        invokeCallback(ALL_TABLE_COLUMNS, allTableColumns);
+        return null;
     }
 
     @Override
     public void visit(AllTableColumns allTableColumns) {
-        invokeCallback(ALL_TABLE_COLUMNS, allTableColumns);
+        ExpressionVisitor.super.visit(allTableColumns);
+    }
+
+    @Override
+    public <S> T visit(AllValue allValue, S context) {
+
+        return null;
     }
 
     @Override
     public void visit(AllValue allValue) {
+        ExpressionVisitor.super.visit(allValue);
+    }
 
+    @Override
+    public <S> T visit(IsDistinctExpression isDistinctExpression, S context) {
+        visitBinaryExpression(isDistinctExpression, context);
+        return null;
     }
 
     @Override
     public void visit(IsDistinctExpression isDistinctExpression) {
-        visitBinaryExpression(isDistinctExpression);
+        ExpressionVisitor.super.visit(isDistinctExpression);
     }
 
     @Override
-    public void visit(SelectItem item) {
+    public <S> T visit(SelectItem<?> item, S context) {
         // TODO: what are .getAliasColumns()? Should we look at them?
         var alias = item.getAlias();
         if (alias != null) {
@@ -849,30 +1258,56 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
         if (alias != null) {
             popContext();
         }
+        return null;
     }
 
     @Override
-    public void visit(UserVariable var) {
-
+    public void visit(SelectItem<? extends Expression> selectItem) {
+        SelectItemVisitor.super.visit(selectItem);
     }
 
     @Override
-    public void visit(NumericBind bind) {
-
+    public <S> T visit(UserVariable var, S context) {
+        return null;
     }
 
     @Override
-    public void visit(KeepExpression aexpr) {
+    public void visit(UserVariable userVariable) {
+        ExpressionVisitor.super.visit(userVariable);
+    }
 
+    @Override
+    public <S> T visit(NumericBind bind, S context) {
+        return null;
+    }
+
+    @Override
+    public void visit(NumericBind numericBind) {
+        ExpressionVisitor.super.visit(numericBind);
+    }
+
+    @Override
+    public <S> T visit(KeepExpression aexpr, S context) {
+        return null;
+    }
+
+    @Override
+    public void visit(KeepExpression keepExpression) {
+        ExpressionVisitor.super.visit(keepExpression);
+    }
+
+    @Override
+    public <S> T visit(MySQLGroupConcat groupConcat, S context) {
+        return null;
     }
 
     @Override
     public void visit(MySQLGroupConcat groupConcat) {
-
+        ExpressionVisitor.super.visit(groupConcat);
     }
 
     @Override
-    public void visit(Delete delete) {
+    public <S> T visit(Delete delete, S context) {
         pushContext(DELETE);
         invokeCallback(MUTATION_COMMAND, "delete");
         visit(delete.getTable());
@@ -891,6 +1326,12 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
             popContext(); // WHERE
         }
         popContext(); // DELETE
+        return null;
+    }
+
+    @Override
+    public void visit(Delete delete) {
+        StatementVisitor.super.visit(delete);
     }
 
     @SuppressWarnings("deprecation")
@@ -941,6 +1382,11 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(Update update) {
+        StatementVisitor.super.visit(update);
+    }
+
+    @Override
     public <S> T visit(Insert insert, S context) {
         pushContext(INSERT);
         invokeCallback(MUTATION_COMMAND, "insert");
@@ -957,9 +1403,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
         return null;
     }
 
+    @Override
+    public void visit(Insert insert) {
+        StatementVisitor.super.visit(insert);
+    }
+
     public <S> T visit(Analyze analyze, S context) {
         visit(analyze.getTable());
         return null;
+    }
+
+    @Override
+    public void visit(Analyze analyze) {
+        StatementVisitor.super.visit(analyze);
     }
 
     @Override
@@ -970,10 +1426,20 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(Drop drop) {
+        StatementVisitor.super.visit(drop);
+    }
+
+    @Override
     public <S> T visit(Truncate truncate, S context) {
         invokeCallback(MUTATION_COMMAND, "truncate");
         visit(truncate.getTable());
         return null;
+    }
+
+    @Override
+    public void visit(Truncate truncate) {
+        StatementVisitor.super.visit(truncate);
     }
 
     @Override
@@ -983,9 +1449,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(CreateIndex createIndex) {
+        StatementVisitor.super.visit(createIndex);
+    }
+
+    @Override
     public <S> T visit(CreateSchema aThis, S context) {
         invokeCallback(MUTATION_COMMAND, "create-schema");
         return null;
+    }
+
+    @Override
+    public void visit(CreateSchema createSchema) {
+        StatementVisitor.super.visit(createSchema);
     }
 
     @Override
@@ -993,9 +1469,14 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
         invokeCallback(MUTATION_COMMAND, "create-table");
         visit(create.getTable());
         if (create.getSelect() != null) {
-            create.getSelect().accept((SelectVisitor) this);
+            create.getSelect().accept((SelectVisitor) this, context);
         }
         return null;
+    }
+
+    @Override
+    public void visit(CreateTable createTable) {
+        StatementVisitor.super.visit(createTable);
     }
 
     @Override
@@ -1005,45 +1486,79 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(CreateView createView) {
+        StatementVisitor.super.visit(createView);
+    }
+
+    @Override
     public <S> T visit(Alter alter, S context) {
         invokeCallback(MUTATION_COMMAND, "alter-table");
         return null;
     }
 
     @Override
+    public void visit(Alter alter) {
+        StatementVisitor.super.visit(alter);
+    }
+
+    @Override
     public <S> T visit(Statements stmts, S context) {
-            throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
-        return null;
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    }
+
+    @Override
+    public void visit(Statements statements) {
+        StatementVisitor.super.visit(statements);
     }
 
     @Override
     public <S> T visit(Execute execute, S context) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
-        return null;
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    }
+
+    @Override
+    public void visit(Execute execute) {
+        StatementVisitor.super.visit(execute);
     }
 
     @Override
     public <S> T visit(SetStatement set, S context) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
-        return null;
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    }
+
+    @Override
+    public void visit(SetStatement set) {
+        StatementVisitor.super.visit(set);
     }
 
     @Override
     public <S> T visit(ResetStatement reset, S context) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
-        return null;
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    }
+
+    @Override
+    public void visit(ResetStatement reset) {
+        StatementVisitor.super.visit(reset);
     }
 
     @Override
     public <S> T visit(ShowColumnsStatement set, S context) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
-        return null;
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    }
+
+    @Override
+    public void visit(ShowColumnsStatement showColumns) {
+        StatementVisitor.super.visit(showColumns);
     }
 
     @Override
     public <S> T visit(ShowIndexStatement showIndex, S context) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
-        return null;
+        throw new AnalysisError(AnalysisErrorType.INVALID_QUERY);
+    }
+
+    @Override
+    public void visit(ShowIndexStatement showIndex) {
+        StatementVisitor.super.visit(showIndex);
     }
 
     @Override
@@ -1055,9 +1570,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(RowConstructor<? extends Expression> rowConstructor) {
+        ExpressionVisitor.super.visit(rowConstructor);
+    }
+
+    @Override
     public <S> T visit(RowGetExpression rowGetExpression, S context) {
         rowGetExpression.getExpression().accept(this);
         return null;
+    }
+
+    @Override
+    public void visit(RowGetExpression rowGetExpression) {
+        ExpressionVisitor.super.visit(rowGetExpression);
     }
 
     @Override
@@ -1067,11 +1592,16 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(HexValue hexValue) {
+        ExpressionVisitor.super.visit(hexValue);
+    }
+
+    @Override
     public <S> T visit(Merge merge, S context) {
         visit(merge.getTable());
         if (merge.getWithItemsList() != null) {
             for (WithItem withItem : merge.getWithItemsList()) {
-                withItem.accept((SelectVisitor) this);
+                withItem.accept((SelectVisitor<T>) this, context);
             }
         }
 
@@ -1084,9 +1614,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(Merge merge) {
+        StatementVisitor.super.visit(merge);
+    }
+
+    @Override
     public <S> T visit(OracleHint hint, S context) {
 
         return null;
+    }
+
+    @Override
+    public void visit(OracleHint hint) {
+        ExpressionVisitor.super.visit(hint);
     }
 
     @Override
@@ -1096,9 +1636,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(TableFunction tableFunction) {
+        FromItemVisitor.super.visit(tableFunction);
+    }
+
+    @Override
     public <S> T visit(AlterView alterView, S context) {
         invokeCallback(MUTATION_COMMAND, "alter-view");
         return null;
+    }
+
+    @Override
+    public void visit(AlterView alterView) {
+        StatementVisitor.super.visit(alterView);
     }
 
     @Override
@@ -1108,8 +1658,18 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(RefreshMaterializedViewStatement materializedView) {
+        StatementVisitor.super.visit(materializedView);
+    }
+
+    @Override
     public <S> T visit(TimeKeyExpression timeKeyExpression, S context) {
         return null;
+    }
+
+    @Override
+    public void visit(TimeKeyExpression timeKeyExpression) {
+        ExpressionVisitor.super.visit(timeKeyExpression);
     }
 
     @Override
@@ -1118,9 +1678,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(DateTimeLiteralExpression dateTimeLiteralExpression) {
+        ExpressionVisitor.super.visit(dateTimeLiteralExpression);
+    }
+
+    @Override
     public <S> T visit(Commit commit, S context) {
 
         return null;
+    }
+
+    @Override
+    public void visit(Commit commit) {
+        StatementVisitor.super.visit(commit);
     }
 
     @Override
@@ -1136,8 +1706,18 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(Upsert upsert) {
+        StatementVisitor.super.visit(upsert);
+    }
+
+    @Override
     public <S> T visit(UseStatement use, S context) {
         return null;
+    }
+
+    @Override
+    public void visit(UseStatement use) {
+        StatementVisitor.super.visit(use);
     }
 
     @Override
@@ -1149,6 +1729,11 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(ParenthesedFromItem parenthesedFromItem) {
+        FromItemVisitor.super.visit(parenthesedFromItem);
+    }
+
+    @Override
     public <S> T visit(GroupByElement element, S context) {
         pushContext(GROUP_BY);
         element.getGroupByExpressionList().accept(this);
@@ -1156,6 +1741,12 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
             exprList.accept(this);
         }
         popContext(); // GROUP_BY
+        return null;
+    }
+
+    @Override
+    public void visit(GroupByElement groupBy) {
+        GroupByVisitor.super.visit(groupBy);
     }
 
     /**
@@ -1189,6 +1780,11 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(Block block) {
+        StatementVisitor.super.visit(block);
+    }
+
+    @Override
     public <S> T visit(Comment comment, S context) {
         if (comment.getTable() != null) {
             visit(comment.getTable());
@@ -1203,15 +1799,30 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(Comment comment) {
+        StatementVisitor.super.visit(comment);
+    }
+
+    @Override
     public <S> T visit(Values values, S context) {
         values.getExpressions().accept(this);
         return null;
     }
 
     @Override
+    public void visit(Values values) {
+        SelectVisitor.super.visit(values);
+    }
+
+    @Override
     public <S> T visit(DescribeStatement describe, S context) {
         describe.getTable().accept(this);
         return null;
+    }
+
+    @Override
+    public void visit(DescribeStatement describe) {
+        StatementVisitor.super.visit(describe);
     }
 
     @Override
@@ -1223,9 +1834,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(ExplainStatement explainStatement) {
+        StatementVisitor.super.visit(explainStatement);
+    }
+
+    @Override
     public <S> T visit(NextValExpression nextVal, S context) {
 
         return null;
+    }
+
+    @Override
+    public void visit(NextValExpression nextValExpression) {
+        ExpressionVisitor.super.visit(nextValExpression);
     }
 
     @Override
@@ -1235,15 +1856,30 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(CollateExpression collateExpression) {
+        ExpressionVisitor.super.visit(collateExpression);
+    }
+
+    @Override
     public <S> T visit(ShowStatement aThis, S context) {
 
         return null;
     }
 
     @Override
+    public void visit(ShowStatement showStatement) {
+        StatementVisitor.super.visit(showStatement);
+    }
+
+    @Override
     public <S> T visit(SimilarToExpression expr, S context) {
-        visitBinaryExpression(expr);
+        visitBinaryExpression(expr, context);
         return null;
+    }
+
+    @Override
+    public void visit(SimilarToExpression similarToExpression) {
+        ExpressionVisitor.super.visit(similarToExpression);
     }
 
     @Override
@@ -1253,9 +1889,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(DeclareStatement declareStatement) {
+        StatementVisitor.super.visit(declareStatement);
+    }
+
+    @Override
     public <S> T visit(Grant grant, S context) {
         invokeCallback(MUTATION_COMMAND, "grant");
         return null;
+    }
+
+    @Override
+    public void visit(Grant grant) {
+        StatementVisitor.super.visit(grant);
     }
 
     @Override
@@ -1274,11 +1920,21 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(ArrayExpression arrayExpression) {
+        ExpressionVisitor.super.visit(arrayExpression);
+    }
+
+    @Override
     public <S> T visit(ArrayConstructor array, S context) {
         for (Expression expression : array.getExpressions()) {
             expression.accept(this);
         }
         return null;
+    }
+
+    @Override
+    public void visit(ArrayConstructor arrayConstructor) {
+        ExpressionVisitor.super.visit(arrayConstructor);
     }
 
     @Override
@@ -1288,9 +1944,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(CreateSequence createSequence) {
+        StatementVisitor.super.visit(createSequence);
+    }
+
+    @Override
     public <S> T visit(AlterSequence alterSequence, S context) {
         invokeCallback(MUTATION_COMMAND, "alter-sequence");
         return null;
+    }
+
+    @Override
+    public void visit(AlterSequence alterSequence) {
+        StatementVisitor.super.visit(alterSequence);
     }
 
     @Override
@@ -1300,22 +1966,63 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(CreateFunctionalStatement createFunctionalStatement) {
+        StatementVisitor.super.visit(createFunctionalStatement);
+    }
+
+    @Override
     public <S> T visit(ShowTablesStatement showTables, S context) {
         throw new UnsupportedOperationException(
                 "Reading from a ShowTablesStatement is not supported");
-        return null;
+    }
+
+    @Override
+    public void visit(ShowTablesStatement showTables) {
+        StatementVisitor.super.visit(showTables);
     }
 
     @Override
     public <S> T visit(TSQLLeftJoin tsqlLeftJoin, S context) {
-        visitBinaryExpression(tsqlLeftJoin);
+        visitBinaryExpression(tsqlLeftJoin, context);
         return null;
     }
 
     @Override
+    public void visit(TSQLLeftJoin tsqlLeftJoin) {
+        ExpressionVisitor.super.visit(tsqlLeftJoin);
+    }
+
+    @Override
     public <S> T visit(TSQLRightJoin tsqlRightJoin, S context) {
-        visitBinaryExpression(tsqlRightJoin);
+        visitBinaryExpression(tsqlRightJoin, context);
         return null;
+    }
+
+    @Override
+    public void visit(TSQLRightJoin tsqlRightJoin) {
+        ExpressionVisitor.super.visit(tsqlRightJoin);
+    }
+
+    @Override
+    public <S> T visit(StructType structType, S s) {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public void visit(StructType structType) {
+        ExpressionVisitor.super.visit(structType);
+    }
+
+    @Override
+    public <S> T visit(LambdaExpression lambdaExpression, S s) {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public void visit(LambdaExpression lambdaExpression) {
+        ExpressionVisitor.super.visit(lambdaExpression);
     }
 
     @Override
@@ -1326,9 +2033,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(VariableAssignment variableAssignment) {
+        ExpressionVisitor.super.visit(variableAssignment);
+    }
+
+    @Override
     public <S> T visit(XMLSerializeExpr aThis, S context) {
 
         return null;
+    }
+
+    @Override
+    public void visit(XMLSerializeExpr xmlSerializeExpr) {
+        ExpressionVisitor.super.visit(xmlSerializeExpr);
     }
 
     @Override
@@ -1338,25 +2055,50 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(CreateSynonym createSynonym) {
+        StatementVisitor.super.visit(createSynonym);
+    }
+
+    @Override
     public <S> T visit(TimezoneExpression aThis, S context) {
         aThis.getLeftExpression().accept(this);
         return null;
     }
 
     @Override
-    return null;
-    public <S> T visit(SavepointStatement savepointStatement, S context) {}
+    public void visit(TimezoneExpression timezoneExpression) {
+        ExpressionVisitor.super.visit(timezoneExpression);
+    }
+
+    @Override
+    public <S> T visit(SavepointStatement savepointStatement, S context) {
+        return null;
+    }
+
+    @Override
+    public void visit(SavepointStatement savepointStatement) {
+        StatementVisitor.super.visit(savepointStatement);
+    }
 
     @Override
     public <S> T visit(RollbackStatement rollbackStatement, S context) {
-
         return null;
+    }
+
+    @Override
+    public void visit(RollbackStatement rollbackStatement) {
+        StatementVisitor.super.visit(rollbackStatement);
     }
 
     @Override
     public <S> T visit(AlterSession alterSession, S context) {
         invokeCallback(MUTATION_COMMAND, "alter-session");
         return null;
+    }
+
+    @Override
+    public void visit(AlterSession alterSession) {
+        StatementVisitor.super.visit(alterSession);
     }
 
     @Override
@@ -1374,6 +2116,11 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(JsonAggregateFunction jsonAggregateFunction) {
+        ExpressionVisitor.super.visit(jsonAggregateFunction);
+    }
+
+    @Override
     public <S> T visit(JsonFunction expression, S context) {
         for (JsonFunctionExpression expr : expression.getExpressions()) {
             expr.getExpression().accept(this);
@@ -1382,9 +2129,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(JsonFunction jsonFunction) {
+        ExpressionVisitor.super.visit(jsonFunction);
+    }
+
+    @Override
     public <S> T visit(ConnectByRootOperator connectByRootOperator, S context) {
         connectByRootOperator.getColumn().accept(this);
         return null;
+    }
+
+    @Override
+    public void visit(ConnectByRootOperator connectByRootOperator) {
+        ExpressionVisitor.super.visit(connectByRootOperator);
     }
 
     public <S> T visit(IfElseStatement ifElseStatement, S context) {
@@ -1399,9 +2156,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
         return null;
     }
 
+    @Override
+    public void visit(IfElseStatement ifElseStatement) {
+        StatementVisitor.super.visit(ifElseStatement);
+    }
+
     public <S> T visit(OracleNamedFunctionParameter oracleNamedFunctionParameter, S context) {
         oracleNamedFunctionParameter.getExpression().accept(this);
         return null;
+    }
+
+    @Override
+    public void visit(OracleNamedFunctionParameter oracleNamedFunctionParameter) {
+        ExpressionVisitor.super.visit(oracleNamedFunctionParameter);
     }
 
     @Override
@@ -1415,6 +2182,11 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(RenameTableStatement renameTableStatement) {
+        StatementVisitor.super.visit(renameTableStatement);
+    }
+
+    @Override
     public <S> T visit(PurgeStatement purgeStatement, S context) {
         invokeCallback(MUTATION_COMMAND, "purge");
         if (purgeStatement.getPurgeObjectType() == PurgeObjectType.TABLE) {
@@ -1424,9 +2196,19 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(PurgeStatement purgeStatement) {
+        StatementVisitor.super.visit(purgeStatement);
+    }
+
+    @Override
     public <S> T visit(AlterSystemStatement alterSystemStatement, S context) {
         invokeCallback(MUTATION_COMMAND, "alter-system");
         return null;
+    }
+
+    @Override
+    public void visit(AlterSystemStatement alterSystemStatement) {
+        StatementVisitor.super.visit(alterSystemStatement);
     }
 
     @Override
@@ -1435,8 +2217,18 @@ public class AstWalker<Acc, T> implements SelectVisitor<T>, FromItemVisitor<T>, 
     }
 
     @Override
+    public void visit(UnsupportedStatement unsupportedStatement) {
+        StatementVisitor.super.visit(unsupportedStatement);
+    }
+
+    @Override
     public <S> T visit(GeometryDistance geometryDistance, S context) {
-        visitBinaryExpression(geometryDistance);
+        visitBinaryExpression(geometryDistance, context);
         return null;
+    }
+
+    @Override
+    public void visit(GeometryDistance geometryDistance) {
+        ExpressionVisitor.super.visit(geometryDistance);
     }
 }

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -137,7 +137,8 @@
   ;; We need to pre-sanitize the SQL before its analyzed so that the AST token positions match up correctly.
   ;; Currently, we use a more complex and expensive sanitization method, so that it's reversible.
   ;; If we decide that it's OK to normalize whitespace etc. during replacement, then we can use the same helper.
-  (let [sql'     (escape-keywords (str/replace sql #"(?m)^\n" " \n") (:non-reserved-words opts))
+  (let [sql'     (-> (str/replace sql #"(?m)^\n" " \n")
+                     (escape-keywords (:non-reserved-words opts)))
         opts'    (select-keys opts [:case-insensitive :quotes-preserve-case? :allow-unused?])
         renames' (walk/postwalk (fn [x]
                                   (if (string? x)

--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -47,14 +47,12 @@
 (defn parsed-query
   "Main entry point: takes a string query and returns a `Statement` object that can be handled by the other functions."
   [^String query & {:as opts}]
-  ;; Dialects like SQLite and Databricks treat consecutive blank lines as implicit semicolons.
-  ;; JSQLParser, as a polyglot parser, always has this behavior, and there is no option to disable it.
-  ;; For Metabase, we are always dealing with single queries, so there's no point ever having this behavior.
-  ;; TODO When JSQLParser 4.10 is released, move to the more robust [[CCJSqlParserUtil.sanitizeSingleSql]] helper.
-  ;; See https://github.com/JSQLParser/JSqlParser/issues/1988
   (try
     (-> query
-        (str/replace #"\n{2,}" "\n")
+        ;; Dialects like SQLite and Databricks treat consecutive blank lines as implicit semicolons.
+        ;; JSQLParser, as a polyglot parser, always has this behavior, and there is no option to disable it.
+        ;; This utility pre-processed the query to remove any such blank lines.
+        (CCJSqlParserUtil/sanitizeSingleSql)
         (escape-keywords (:non-reserved-words opts))
         (CCJSqlParserUtil/parse (->parser-fn opts)))
     (catch JSQLParserException e
@@ -82,7 +80,7 @@
   (Specifically, it returns their fully-qualified names as strings, where 'fully-qualified' means 'as referred to in
   the query'; this function doesn't do additional inference work to find out a table's schema.)"
   [parsed & {:as opts}]
-  ;; By default, we will preserve identifiers verbatim, to be agnostic of case and quote behavior.
+  ;; By default, we will preserve identifiers verbatim, to be agnostic of casing and quoting.
   ;; This may result in duplicate components, which are left to the caller to deduplicate.
   ;; In Metabase's case, this is done during the stage where the database metadata is queried.
   (try

--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -69,10 +69,10 @@
      sql
      (mw/fold-query
       updated-ast
-      {:table  (replace-name #(let [fqn   (.getFullyQualifiedName ^Table %)
-                                    alias (.getAlias ^Table %)]
-                                (if alias
-                                  (str fqn " " (.getName alias))
+      {:table  (replace-name #(let [fqn     (.getFullyQualifiedName ^Table %)
+                                    t-alias (.getAlias ^Table %)]
+                                (if t-alias
+                                  (str fqn " " (.getName t-alias))
                                   fqn)))
        :column (replace-name #(.getFullyQualifiedName ^Column %))}
       []))))

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -77,10 +77,11 @@ from foo")
 (deftest three-or-more-line-breaks-test
   (doseq [f [identity ->windows]
           :let [query (f implicit-semicolon)]]
-    (is (= (-> query (str/replace "id" "pk") (str/replace "foo" "bar"))
-           (m/replace-names query
-                            {:columns {{:table "foo" :column "id"} "pk"}
-                             :tables  {{:table "foo"} "bar"}})))))
+    (testing (if (= ->windows f) "windows" "unix")
+      (is (= (-> query (str/replace "id" "pk") (str/replace "foo" "bar"))
+             (m/replace-names query
+                              {:columns {{:table "foo" :column "id"} "pk"}
+                               :tables  {{:table "foo"} "bar"}}))))))
 
 (deftest query->tables-test
   (testing "Simple queries"

--- a/test/resources/acceptance/between__broken_49.analysis.edn
+++ b/test/resources/acceptance/between__broken_49.analysis.edn
@@ -1,0 +1,3 @@
+{:source-columns [{:table "usage_stats" :column "instance_started"}
+                  {:table "usage_stats" :column "time_finished"}]
+ :tables         [{:table "usage_stats"}]}

--- a/test/resources/acceptance/broken__between.analysis.edn
+++ b/test/resources/acceptance/broken__between.analysis.edn
@@ -1,5 +1,0 @@
-{:source-columns [{:table "usage-stats" :column "instance_started"}
-                  {:table "usage-stats" :column "month_started"}
-                  {:table "usage-stats" :column "instance_finished"}]
- :tables         [{:table "usage_stats"}]
- :overrides      :macaw.error/unable-to-parse}

--- a/test/resources/acceptance/queries.sql
+++ b/test/resources/acceptance/queries.sql
@@ -12,7 +12,7 @@ WHERE
   _TABLE_SUFFIX BETWEEN '20230101' AND '20230131'
 LIMIT 1000;
 
--- FIXTURE: broken/between
+-- FIXTURE: between/broken-49
 SELECT
     date_trunc('month', instance_started)::DATE AS month_started,
     avg(time_finished - instance_started) as avg_runtime,


### PR DESCRIPTION
Closes #91 
Closes #73 

This upgrades us to the latest JSQLParser, which fixes one of our fixtures.

Unfortunately it seems there is a bug in the tokens, they are giving off-by-one errors on their line, which was a real pain to discover after going down so many other rabbit holes. They also changed the scope of the Table node to include the alias, which was also quite annoying.

The new Visitor interfaces are really more Foldable / Traversibles, which is great - it means we can use them to make the completeness of our newer walkers statically verified, but I have not done that here yet.