### PR TITLE
Don't override default Malli registry

### DIFF
--- a/src/macaw/util/malli/registry.clj
+++ b/src/macaw/util/malli/registry.clj
@@ -59,8 +59,6 @@
 
 (defonce ^:private registry (malli.registry/mutable-registry registry*))
 
-(malli.registry/set-default-registry! registry)
-
 (defn register!
   "Register a spec with our Malli spec registry."
   [schema definition]

--- a/test/resources/acceptance/queries.sql
+++ b/test/resources/acceptance/queries.sql
@@ -287,6 +287,9 @@ FROM user;
 -- FIXTURE: simple/select-star
 SELECT * FROM t;
 
+-- FIXTURE: simple/select-count
+SELECT COUNT(*) FROM t;
+
 -- FIXTURE: snowflakelet
 SELECT
     column_2564,

--- a/test/resources/acceptance/simple__select_count.analysis.edn
+++ b/test/resources/acceptance/simple__select_count.analysis.edn
@@ -1,0 +1,3 @@
+{:has-wildcard?  #{}
+ :source-columns []
+ :tables         [{:table "t"}]}


### PR DESCRIPTION
This should fix a cataclysm when importing into Metabase.

A trivial test case comes along for the ride.