### PR TITLE
Fix renaming where only the schema changes

### DIFF
--- a/src/macaw/core.clj
+++ b/src/macaw/core.clj
@@ -230,8 +230,8 @@
           (unescape-keywords (:non-reserved-words opts))))))
 
 (defn ->ast
-  "Given a sql query, return a clojure ast that represents it.
+  "Given an SQL query, return a clojure AST that represents it.
 
-   This ast can potentially be lossy and generally shouldn't be as part of a round trip back to sql."
+   This AST can potentially be lossy, and generally shouldn't be used as part of a round trip back to SQL."
   [parsed]
   (m.ast/->ast parsed {:with-instance? false}))

--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -4,7 +4,6 @@
    [macaw.util :as u]
    [macaw.walk :as mw])
   (:import
-   (net.sf.jsqlparser.expression Alias)
    (net.sf.jsqlparser.parser ASTNodeAccess SimpleNode)
    (net.sf.jsqlparser.schema Column Table)))
 
@@ -97,37 +96,47 @@
       []))))
 
 (defn- rename-table
+  "Rename a table and/or its schema."
   [updated-nodes table-renames schema-renames known-tables opts ^Table t _ctx]
-  (let [kt      (get known-tables t)
-        aliases (into #{} (comp
-                           (keep #(.getAlias ^Table %))
-                           (map #(.getName ^Alias %)))
-                      (:instances kt))]
-    ;; Don't rename this node if it's pointing at an alias
-    ;; TODO (2025-11-26) this can have false negatives due to case or quoting
-    (when (or (.getAlias t) (not (aliases (.getName t))))
-      (let [raw-table  (.getName t)
-            raw-schema (.getSchemaName t)
-            table-rename (u/find-relevant table-renames (get known-tables t) [:table :schema])]
-        ;; Apply table rename if found
-        (when table-rename
+  (let [raw-table    (.getName t)
+        raw-schema   (.getSchemaName t)
+        table-rename (u/find-relevant table-renames (get known-tables t) [:table :schema])]
+    ;; Apply table rename only if the literal name matches the expected table name.
+    ;; This is purely textual matching - we don't try to distinguish aliases from table
+    ;; references because we might be wrong due to scoping (CTEs, subqueries, etc.).
+    (when table-rename
+      (let [expected-table (:table (key table-rename))
+            normalized-expected (collect/normalize-reference expected-table opts)
+            ;; When normalized-expected is a Pattern (agnostic mode), we need to match against
+            ;; the raw string, not another Pattern. Otherwise normalize both sides.
+            names-match? (fn [raw-name]
+                           (if (instance? java.util.regex.Pattern normalized-expected)
+                             (u/match-component normalized-expected raw-name)
+                             (u/match-component normalized-expected
+                                                (collect/normalize-reference raw-name opts))))]
+        (when (names-match? raw-table)
           (vswap! updated-nodes conj [t table-rename])
           (let [rename-val (val table-rename)
                 table-name (if (map? rename-val) (:table rename-val) rename-val)]
             (.setName t (preserve-quotes raw-table table-name))
+            ;; Also rename alias if it matches the original table name
+            (when-let [t-alias (.getAlias t)]
+              (let [alias-name (.getName t-alias)]
+                (when (names-match? alias-name)
+                  (.setName t-alias (preserve-quotes alias-name table-name)))))
             ;; If the table rename includes a :schema key, use it (nil removes the schema)
             (when (and (map? rename-val) (contains? rename-val :schema))
               (let [new-schema (:schema rename-val)]
-                (.setSchemaName t (when new-schema (preserve-quotes raw-schema new-schema)))))))
-        ;; Apply schema rename only if table rename didn't already set the schema
-        (when-not (and table-rename
-                       (map? (val table-rename))
-                       (contains? (val table-rename) :schema))
-          (let [schema-name (collect/normalize-reference raw-schema opts)]
-            (when-let [schema-rename (u/seek (comp (partial u/match-component schema-name) key) schema-renames)]
-              (vswap! updated-nodes conj [t schema-rename])
-              (let [identifier (as-> (val schema-rename) % (:table % %))]
-                (.setSchemaName t (preserve-quotes raw-schema identifier))))))))))
+                (.setSchemaName t (when new-schema (preserve-quotes raw-schema new-schema)))))))))
+    ;; Apply schema rename only if table rename didn't already set the schema
+    (when-not (and table-rename
+                   (map? (val table-rename))
+                   (contains? (val table-rename) :schema))
+      (let [schema-name (collect/normalize-reference raw-schema opts)]
+        (when-let [schema-rename (u/seek (comp (partial u/match-component schema-name) key) schema-renames)]
+          (vswap! updated-nodes conj [t schema-rename])
+          (let [identifier (as-> (val schema-rename) % (:table % %))]
+            (.setSchemaName t (preserve-quotes raw-schema identifier))))))))
 
 (defn- rename-column
   [updated-nodes column-renames known-columns ^Column c _ctx]

--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -4,6 +4,7 @@
    [macaw.util :as u]
    [macaw.walk :as mw])
   (:import
+   (net.sf.jsqlparser.expression Alias)
    (net.sf.jsqlparser.parser ASTNodeAccess SimpleNode)
    (net.sf.jsqlparser.schema Column Table)))
 
@@ -96,47 +97,37 @@
       []))))
 
 (defn- rename-table
-  "Rename a table and/or its schema."
   [updated-nodes table-renames schema-renames known-tables opts ^Table t _ctx]
-  (let [raw-table    (.getName t)
-        raw-schema   (.getSchemaName t)
-        table-rename (u/find-relevant table-renames (get known-tables t) [:table :schema])]
-    ;; Apply table rename only if the literal name matches the expected table name.
-    ;; This is purely textual matching - we don't try to distinguish aliases from table
-    ;; references because we might be wrong due to scoping (CTEs, subqueries, etc.).
-    (when table-rename
-      (let [expected-table (:table (key table-rename))
-            normalized-expected (collect/normalize-reference expected-table opts)
-            ;; When normalized-expected is a Pattern (agnostic mode), we need to match against
-            ;; the raw string, not another Pattern. Otherwise normalize both sides.
-            names-match? (fn [raw-name]
-                           (if (instance? java.util.regex.Pattern normalized-expected)
-                             (u/match-component normalized-expected raw-name)
-                             (u/match-component normalized-expected
-                                                (collect/normalize-reference raw-name opts))))]
-        (when (names-match? raw-table)
+  (let [kt      (get known-tables t)
+        aliases (into #{} (comp
+                           (keep #(.getAlias ^Table %))
+                           (map #(.getName ^Alias %)))
+                      (:instances kt))]
+    ;; Don't rename this node if it's pointing at an alias
+    ;; TODO (2025-11-26) this can have false negatives due to case or quoting
+    (when (or (.getAlias t) (not (aliases (.getName t))))
+      (let [raw-table  (.getName t)
+            raw-schema (.getSchemaName t)
+            table-rename (u/find-relevant table-renames (get known-tables t) [:table :schema])]
+        ;; Apply table rename if found
+        (when table-rename
           (vswap! updated-nodes conj [t table-rename])
           (let [rename-val (val table-rename)
                 table-name (if (map? rename-val) (:table rename-val) rename-val)]
             (.setName t (preserve-quotes raw-table table-name))
-            ;; Also rename alias if it matches the original table name
-            (when-let [t-alias (.getAlias t)]
-              (let [alias-name (.getName t-alias)]
-                (when (names-match? alias-name)
-                  (.setName t-alias (preserve-quotes alias-name table-name)))))
             ;; If the table rename includes a :schema key, use it (nil removes the schema)
             (when (and (map? rename-val) (contains? rename-val :schema))
               (let [new-schema (:schema rename-val)]
-                (.setSchemaName t (when new-schema (preserve-quotes raw-schema new-schema)))))))))
-    ;; Apply schema rename only if table rename didn't already set the schema
-    (when-not (and table-rename
-                   (map? (val table-rename))
-                   (contains? (val table-rename) :schema))
-      (let [schema-name (collect/normalize-reference raw-schema opts)]
-        (when-let [schema-rename (u/seek (comp (partial u/match-component schema-name) key) schema-renames)]
-          (vswap! updated-nodes conj [t schema-rename])
-          (let [identifier (as-> (val schema-rename) % (:table % %))]
-            (.setSchemaName t (preserve-quotes raw-schema identifier))))))))
+                (.setSchemaName t (when new-schema (preserve-quotes raw-schema new-schema)))))))
+        ;; Apply schema rename only if table rename didn't already set the schema
+        (when-not (and table-rename
+                       (map? (val table-rename))
+                       (contains? (val table-rename) :schema))
+          (let [schema-name (collect/normalize-reference raw-schema opts)]
+            (when-let [schema-rename (u/seek (comp (partial u/match-component schema-name) key) schema-renames)]
+              (vswap! updated-nodes conj [t schema-rename])
+              (let [identifier (as-> (val schema-rename) % (:table % %))]
+                (.setSchemaName t (preserve-quotes raw-schema identifier))))))))))
 
 (defn- rename-column
   [updated-nodes column-renames known-columns ^Column c _ctx]

--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -106,8 +106,8 @@
     ;; Don't rename this node if it's pointing at an alias
     ;; TODO (2025-11-26) this can have false negatives due to case or quoting
     (when (or (.getAlias t) (not (aliases (.getName t))))
-      (let [raw-table  (.getName t)
-            raw-schema (.getSchemaName t)
+      (let [raw-schema   (.getSchemaName t)
+            raw-table    (.getName t)
             table-rename (u/find-relevant table-renames (get known-tables t) [:table :schema])]
         ;; Apply table rename if found
         (when table-rename

--- a/src/macaw/rewrite.clj
+++ b/src/macaw/rewrite.clj
@@ -4,6 +4,7 @@
    [macaw.util :as u]
    [macaw.walk :as mw])
   (:import
+   (net.sf.jsqlparser.expression Alias)
    (net.sf.jsqlparser.parser ASTNodeAccess SimpleNode)
    (net.sf.jsqlparser.schema Column Table)))
 
@@ -68,23 +69,21 @@
     (str sb)))
 
 (defn- update-query
-  "Emit a SQL string for an updated AST, preserving the comments and whitespace from the original SQL."
+  "Emit the SQL string for an updated AST, preserving the comments and whitespace from the original SQL."
   [updated-ast updated-nodes sql & {:as _opts}]
-  (let [updated-node?        (set (map first updated-nodes))
-        ;; Schema renames on qualifiers should propagate to column output
-        schema-renamed-node? (set (keep (fn [[node info]]
-                                          (when (:schema-rename? info) node))
-                                        updated-nodes))
-        replacement          (fn [->text visitable]
-                               (let [ast-node  (.getASTNode ^ASTNodeAccess visitable)
-                                     idx-range (node->idx-range ast-node sql)
-                                     node-text (->text visitable)]
-                                 [idx-range node-text]))
-        replace-name         (fn [->text]
-                               (fn [acc visitable _ctx]
-                                 (cond-> acc
-                                   (updated-node? visitable)
-                                   (conj (replacement ->text visitable)))))]
+  (let [updated-node? (into #{} (map first) updated-nodes)
+        replacement   (fn [->text visitable]
+                        (let [ast-node  (.getASTNode ^ASTNodeAccess visitable)
+                              idx-range (node->idx-range ast-node sql)
+                              node-text (->text visitable)]
+                          [idx-range node-text]))
+        replace-name  (fn [->text]
+                        (fn [acc visitable _ctx]
+                          (cond-> acc
+                            (or (updated-node? visitable)
+                                (when (instance? Column visitable)
+                                  (updated-node? (.getTable ^Column visitable))))
+                            (conj (replacement ->text visitable)))))]
     (splice-replacements
      sql
      (mw/fold-query
@@ -94,51 +93,53 @@
                                 (if t-alias
                                   (str fqn " " (.getName t-alias))
                                   fqn)))
-       ;; For columns, also check if the qualifier's schema was renamed
-       :column (fn [acc ^Column c _ctx]
-                 (if (or (updated-node? c)
-                         (schema-renamed-node? (.getTable c)))
-                   (conj acc (replacement #(.getFullyQualifiedName ^Column %) c))
-                   acc))}
+       :column (replace-name #(.getFullyQualifiedName ^Column %))}
       []))))
 
 (defn- rename-table
   [updated-nodes table-renames schema-renames known-tables opts ^Table t _ctx]
-  (let [raw-schema        (.getSchemaName t)
-        raw-table         (.getName t)
-        normalized-schema (collect/normalize-reference raw-schema opts)
-        table-rename      (u/find-relevant table-renames (get known-tables t) [:table :schema])
-        schema-rename     (u/seek (comp (partial u/match-component normalized-schema) key) schema-renames)]
-    ;; Apply table rename if found
-    (when table-rename
-      (vswap! updated-nodes conj [t table-rename])
-      (let [rename-val (val table-rename)
-            table-name (if (map? rename-val) (:table rename-val) rename-val)]
-        (.setName t (preserve-quotes raw-table table-name))
-        ;; If the table rename includes a :schema key, use it (nil removes the schema)
-        (when (and (map? rename-val) (contains? rename-val :schema))
-          (let [new-schema (:schema rename-val)]
-            (.setSchemaName t (when new-schema (preserve-quotes raw-schema new-schema)))))))
-    ;; Apply schema rename only if table rename didn't specify a schema
-    (when (and schema-rename
-               (not (and table-rename (map? (val table-rename)) (contains? (val table-rename) :schema))))
-      (vswap! updated-nodes conj [t {:entry schema-rename :schema-rename? true}])
-      (let [identifier (as-> (val schema-rename) % (:table % %))]
-        (.setSchemaName t (preserve-quotes raw-schema identifier))))))
+  (let [kt      (get known-tables t)
+        aliases (into #{} (comp
+                           (keep #(.getAlias ^Table %))
+                           (map #(.getName ^Alias %)))
+                      (:instances kt))]
+    ;; Don't rename this node if it's pointing at an alias
+    ;; TODO (2025-11-26) this can have false negatives due to case or quoting
+    (when (or (.getAlias t) (not (aliases (.getName t))))
+      (let [raw-table  (.getName t)
+            raw-schema (.getSchemaName t)
+            table-rename (u/find-relevant table-renames (get known-tables t) [:table :schema])]
+        ;; Apply table rename if found
+        (when table-rename
+          (vswap! updated-nodes conj [t table-rename])
+          (let [rename-val (val table-rename)
+                table-name (if (map? rename-val) (:table rename-val) rename-val)]
+            (.setName t (preserve-quotes raw-table table-name))
+            ;; If the table rename includes a :schema key, use it (nil removes the schema)
+            (when (and (map? rename-val) (contains? rename-val :schema))
+              (let [new-schema (:schema rename-val)]
+                (.setSchemaName t (when new-schema (preserve-quotes raw-schema new-schema)))))))
+        ;; Apply schema rename only if table rename didn't already set the schema
+        (when-not (and table-rename
+                       (map? (val table-rename))
+                       (contains? (val table-rename) :schema))
+          (let [schema-name (collect/normalize-reference raw-schema opts)]
+            (when-let [schema-rename (u/seek (comp (partial u/match-component schema-name) key) schema-renames)]
+              (vswap! updated-nodes conj [t schema-rename])
+              (let [identifier (as-> (val schema-rename) % (:table % %))]
+                (.setSchemaName t (preserve-quotes raw-schema identifier))))))))))
 
 (defn- rename-column
   [updated-nodes column-renames known-columns ^Column c _ctx]
   (when-let [rename (u/find-relevant column-renames (get known-columns c) [:column :table :schema])]
-    ;; Handle both raw string renames, as well as more precise element based ones.
+    ;; Handle both raw string renames, and more precise element based ones.
     (vswap! updated-nodes conj [c rename])
     (let [raw-column (.getColumnName c)
           identifier (as-> (val rename) % (:column % %))]
       (.setColumnName c (preserve-quotes raw-column identifier)))))
 
 (defn- alert-unused! [updated-nodes renames]
-  (let [;; Extract the rename entry from each updated node (handles both plain entries and {:entry e} maps)
-        extract-entry (fn [[_node info]] (if (map? info) (:entry info) info))
-        known-rename? (set (map extract-entry updated-nodes))]
+  (let [known-rename? (into #{} (map second) updated-nodes)]
     (doseq [[k items] renames]
       (when-let [unknown (first (remove known-rename? items))]
         (throw (ex-info (str "Unknown rename: " unknown) {:type   k
@@ -151,7 +152,7 @@
              [i c])))
 
 (defn replace-names
-  "Given a SQL query and its corresponding (untransformed) AST, apply the given table and column renames."
+  "Given an SQL query and its corresponding (untransformed) AST, apply the given table and column renames."
   [sql parsed-ast renames & {:as opts}]
   (let [{schema-renames :schemas
          table-renames  :tables

--- a/src/macaw/util.clj
+++ b/src/macaw/util.clj
@@ -35,9 +35,9 @@
   "Check whether the given literal matches the expected literal or pattern."
   [expected actual]
   (when expected
-    (if (instance? Pattern expected)
-      (boolean (re-find expected actual))
-      (= expected actual))))
+    (or (= expected actual)
+        (when (and (instance? Pattern expected) (string? actual))
+          (boolean (re-find expected actual))))))
 
 (defn- match-keys
   "Returns a predicate that checks if a map entry matches the element.

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -473,11 +473,13 @@ from foo")
          (m/replace-names "SELECT p.id, q.id FROM public.orders p join private.orders q"
                           {:tables {{:schema "public" :table "orders"} "whatever"}})))
 
-  (is (= "SELECT p.id FROM public.q p"
+  ;; When table name and alias match, both get renamed along with column qualifiers
+  (is (= "SELECT q.id FROM public.q q"
          (m/replace-names "SELECT p.id FROM public.p p"
                           {:tables {{:schema "public" :table "p"} "q"}})))
 
-  (is (= "SELECT p.id FROM public.q P"
+  ;; With case-insensitive matching, alias P matches table name p and gets renamed
+  (is (= "SELECT p.id FROM public.q q"
          (m/replace-names "SELECT p.id FROM public.p P"
                           {:tables {{:schema "public" :table "p"} "q"}}
                           {:case-insensitive :agnostic})))
@@ -559,6 +561,7 @@ from foo")
     (is (= "SELECT * FROM isolated.y"
            (m/replace-names "SELECT * FROM x"
                             {:tables {{:table "x"} {:schema "isolated" :table "y"}}})))
+    ;; Column qualifier `a` doesn't textually match table name `x`, so it's not renamed
     (is (= "SELECT a.id FROM isolated.y a"
            (m/replace-names "SELECT a.id FROM x a"
                             {:tables {{:table "x"} {:schema "isolated" :table "y"}}})))
@@ -692,6 +695,7 @@ from foo")
              (m/replace-names alias-shadow-query
                               {:columns {{:table "people" :column "foo"} "bar"}}
                               {:allow-unused? true})))))
+
 
 (def ^:private cte-query
   "WITH engineering_employees AS (

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -473,13 +473,11 @@ from foo")
          (m/replace-names "SELECT p.id, q.id FROM public.orders p join private.orders q"
                           {:tables {{:schema "public" :table "orders"} "whatever"}})))
 
-  ;; When table name and alias match, both get renamed along with column qualifiers
-  (is (= "SELECT q.id FROM public.q q"
+  (is (= "SELECT p.id FROM public.q p"
          (m/replace-names "SELECT p.id FROM public.p p"
                           {:tables {{:schema "public" :table "p"} "q"}})))
 
-  ;; With case-insensitive matching, alias P matches table name p and gets renamed
-  (is (= "SELECT p.id FROM public.q q"
+  (is (= "SELECT p.id FROM public.q P"
          (m/replace-names "SELECT p.id FROM public.p P"
                           {:tables {{:schema "public" :table "p"} "q"}}
                           {:case-insensitive :agnostic})))
@@ -584,7 +582,6 @@ from foo")
     (is (= "SELECT * FROM isolated.y"
            (m/replace-names "SELECT * FROM x"
                             {:tables {{:table "x"} {:schema "isolated" :table "y"}}})))
-    ;; Column qualifier `a` doesn't textually match table name `x`, so it's not renamed
     (is (= "SELECT a.id FROM isolated.y a"
            (m/replace-names "SELECT a.id FROM x a"
                             {:tables {{:table "x"} {:schema "isolated" :table "y"}}})))

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -546,17 +546,10 @@ from foo")
                            :tables  {{:schema "public" :table "orders"} "purchases"}
                            :columns {{:schema "public" :table "orders" :column "x"} "xx"}}))))
 
-(def ^:private cte-before-replace
-  "WITH z AS (SELECT * FROM a)
-   SELECT c FROM z")
-
-(def ^:private cte-after-replace
-  "WITH z AS (SELECT * FROM b)
-   SELECT c FROM z")
-
 (deftest replace-within-cte-test
-  (is (= cte-after-replace
-         (m/replace-names cte-before-replace {:tables {{:table "a"} "b"}})))
+  (is (ws= "WITH z AS (SELECT * FROM b) SELECT c FROM z"
+           (m/replace-names "WITH z AS (SELECT * FROM a) SELECT c FROM z"
+                            {:tables {{:table "a"} "b"}})))
 
   (testing "with shadowing"
     ;; TODO fix this, which is broken due to shadowing

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -559,14 +559,13 @@ from foo")
          (m/replace-names cte-before-replace {:tables {{:table "a"} "b"}})))
 
   (testing "with shadowing"
-    (let [rr #(str/replace % "z" "a")]
-        ;; TODO fix this, which is broken due to shadowing
-        (is (= #_(rr cte-after-replace)
+    ;; TODO fix this, which is broken due to shadowing
+    (is (ws= #_"WITH a AS (SELECT * FROM b) SELECT c FROM a"
              ;; We treat references to the table `a` as if they were references to the CTE, and therefore leave them.
-             (rr cte-before-replace)
-             (m/replace-names (rr cte-before-replace)
+             "WITH a AS (SELECT * FROM a) SELECT c FROM a"
+             (m/replace-names "WITH a AS (SELECT * FROM a) SELECT c FROM a"
                               {:tables {{:table "a"} "b"}}
-                              {:allow-unused? true}))))))
+                              {:allow-unused? true})))))
 
 
 (deftest allow-unused-test

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -211,10 +211,16 @@ from foo")
                            :tables  {{:schema "public" :table "DOGS"} "cats"}
                            :columns {{:schema "PUBLIC" :table "dogs" :column "bark"} "meow"}}
                           {:case-insensitive :agnostic
-                           :allow-unused?    true}))))
+                           :allow-unused?    true})))
+
+  (testing "Updating the schema only"
+    (is (= "SELECT bark FROM private.dogs"
+           (m/replace-names "SELECT bark FROM PUBLIC.dogs"
+                            {:schemas {"public" "private"}}
+                            {:case-insensitive :lower})))))
 
 (def ^:private heavily-quoted-query-mixed-case
-  "SELECT RAW, \"Foo\", \"doNg\".\"bAr\", `ding`.`doNg`.`feE` FROM `ding`.`doNg`")
+  "SELECT RAW, \"Foo\", \"doNg\".\"bAr\", `ding`.`doNg`.`feE` FROM `dIng`.`doNg`")
 
 ;; With quotes-preserve-case?, only the schema "ding" matches (same case as `ding`)
 ;; The table and columns have different case and won't match
@@ -242,12 +248,22 @@ from foo")
                                              :case-insensitive :agnostic
                                              :quotes-preserve-case? true))))
     (testing "Only matching identifiers are renamed when allowed to run partially"
-      (is (= heavily-quoted-query-mixed-case-rewritten
+      ;; Note: `dIng` (capital I) in FROM doesn't match `ding` with quotes-preserve-case
+      ;; so only the column's schema (lowercase `ding`) gets renamed
+      (is (= "SELECT RAW, \"Foo\", \"doNg\".\"bAr\", `king`.`doNg`.`feE` FROM `dIng`.`doNg`"
              (m/replace-names heavily-quoted-query-mixed-case
                               heavily-quoted-query-rewrites
                               {:case-insensitive      :agnostic
                                :quotes-preserve-case? true
-                               :allow-unused?         true}))))))
+                               :allow-unused?         true}))))
+    (testing "The query is unchanged when there are no exact matches"
+      (let [with-no-exact-matches (str/replace heavily-quoted-query-mixed-case "ding" "dIng")]
+        (is (= with-no-exact-matches
+               (m/replace-names with-no-exact-matches
+                                heavily-quoted-query-rewrites
+                                {:case-insensitive      :agnostic
+                                 :quotes-preserve-case? true
+                                 :allow-unused?         true})))))))
 
 (def ^:private ambiguous-case-replacements
   {:columns {{:schema "public" :table "DOGS" :column "BARK"}  "MEOW"
@@ -445,10 +461,11 @@ from foo")
   ;; To consider - we could avoid splitting up the renames into column and table portions in the client, as
   ;; qualified targets would allow us to infer such changes. Partial qualification could also work fine where there
   ;; is no ambiguity - even if this is just a nice convenience for testing.
-  #_(is (= "SELECT aa.xx, b.x, b.y FROM aa, b;"
-           (m/replace-names "SELECT a.x, b.x, b.y FROM a, b;"
-                            {:columns {{:schema "public" :table "a" :column "x"}
-                                       {:table "aa" :column "xx"}}})))
+  (is (= "SELECT aa.xx, b.x, b.y FROM aa, b;"
+         (m/replace-names "SELECT a.x, b.x, b.y FROM a, b;"
+                          {:tables  {{:table "a"} "aa"}
+                           :columns {{:schema "public" :table "a" :column "x"}
+                                     {:table "aa" :column "xx"}}})))
 
   (is (= "SELECT qwe FROM orders"
          (m/replace-names "SELECT id FROM orders"
@@ -457,6 +474,15 @@ from foo")
   (is (= "SELECT p.id, q.id FROM public.whatever p join private.orders q"
          (m/replace-names "SELECT p.id, q.id FROM public.orders p join private.orders q"
                           {:tables {{:schema "public" :table "orders"} "whatever"}})))
+
+  (is (= "SELECT p.id FROM public.q p"
+         (m/replace-names "SELECT p.id FROM public.p p"
+                          {:tables {{:schema "public" :table "p"} "q"}})))
+
+  (is (= "SELECT p.id FROM public.q P"
+         (m/replace-names "SELECT p.id FROM public.p P"
+                          {:tables {{:schema "public" :table "p"} "q"}}
+                          {:case-insensitive :agnostic})))
 
   (is (ws= "SELECT SUM(public.orders.total) AS s,
             MAX(orders.total) AS max,
@@ -489,13 +515,38 @@ from foo")
 (deftest replace-names-error-test
   (is (thrown-with-msg? ExceptionInfo #"Unable to parse" (m/replace-names "select * from orders limit" {} {}))))
 
+(deftest replace-intended-test
+  (is (= "SELECT S1.T1.C1, T2.C2, C3 FROM S1.T1 JOIN S2.T2"
+         (m/replace-names "SELECT s1.t1.c1, t2.c2, c3 FROM s1.t1 JOIN s2.t2"
+                          {:schemas {"s1" "S1", "s2" "S2"}
+                           :tables  {{:schema "s1" :table "t1"} "T1"
+                                     {:schema "s2" :table "t2"} "T2"}
+                           :columns {{:schema "s1" :table "t1" :column "c1"} "C1"
+                                     {:schema "s2" :table "t2" :column "c2"} "C2"
+                                     {:schema "s2" :table "t2" :column "c3"} "C3"}}))))
+
+(deftest replace-precision-test
+  (is (= "SELECT p.a.x, q.b.y, c.z FROM p.a, q.b, q.c"
+         (m/replace-names "SELECT s1.t1.a, s2.t1.a, t2.a FROM s1.t1, s2.t1, s2.t2"
+                          {:schemas {"s1" "p", "s2" "q"}
+                           :tables  {{:schema "s1" :table "t1"} "a"
+                                     {:schema "s2" :table "t1"} "b"
+                                     {:schema "s2" :table "t2"} "c"}
+                           :columns {{:schema "s1" :table "t1" :column "a"} "x"
+                                     {:schema "s2" :table "t1" :column "a"} "y"
+                                     {:schema "s2" :table "t2" :column "a"} "z"}}))))
+
+(deftest replace-schema-only-test
+  (is (= "SELECT totally_private.orders.x FROM totally_private.orders, private.orders WHERE x = 1"
+         (m/replace-names "SELECT public.orders.x FROM public.orders, private.orders WHERE x = 1"
+                          {:schemas {"public" "totally_private"}}))))
+
 (deftest replace-schema-test
-  ;; Somehow we broke renaming the `x` in the WHERE clause.
-  #_(is (= "SELECT totally_private.purchases.xx FROM totally_private.purchases, private.orders WHERE xx = 1"
-           (m/replace-names "SELECT public.orders.x FROM public.orders, private.orders WHERE x = 1"
-                            {:schemas {"public" "totally_private"}
-                             :tables  {{:schema "public" :table "orders"} "purchases"}
-                             :columns {{:schema "public" :table "orders" :column "x"} "xx"}}))))
+  (is (= "SELECT totally_private.purchases.xx FROM totally_private.purchases, private.orders WHERE xx = 1"
+         (m/replace-names "SELECT public.orders.x FROM public.orders, private.orders WHERE x = 1"
+                          {:schemas {"public" "totally_private"}
+                           :tables  {{:schema "public" :table "orders"} "purchases"}
+                           :columns {{:schema "public" :table "orders" :column "x"} "xx"}}))))
 
 (deftest allow-unused-test
   (is (thrown-with-msg?

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -548,6 +548,29 @@ from foo")
                            :tables  {{:schema "public" :table "orders"} "purchases"}
                            :columns {{:schema "public" :table "orders" :column "x"} "xx"}}))))
 
+(def ^:private cte-before-replace
+  "WITH z AS (SELECT * FROM a)
+   SELECT c FROM z")
+
+(def ^:private cte-after-replace
+  "WITH z AS (SELECT * FROM b)
+   SELECT c FROM z")
+
+(deftest replace-within-cte-test
+  (is (= cte-after-replace
+         (m/replace-names cte-before-replace {:tables {{:table "a"} "b"}})))
+
+  (testing "with shadowing"
+    (let [rr #(str/replace % "z" "a")]
+        ;; TODO fix this, which is broken due to shadowing
+        (is (= #_(rr cte-after-replace)
+             ;; We treat references to the table `a` as if they were references to the CTE, and therefore leave them.
+             (rr cte-before-replace)
+             (m/replace-names (rr cte-before-replace)
+                              {:tables {{:table "a"} "b"}}
+                              {:allow-unused? true}))))))
+
+
 (deftest allow-unused-test
   (is (thrown-with-msg?
        Exception #"Unknown rename"

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -224,9 +224,9 @@ from foo")
 
 ;; With quotes-preserve-case?, only the schema "ding" matches (same case as `ding`)
 ;; The table and columns have different case and won't match
-;; Note: backticks are preserved from the original `ding` schema
+;; Note: `dIng` (capital I) in FROM doesn't match `ding`, so only the column's schema gets renamed
 (def ^:private heavily-quoted-query-mixed-case-rewritten
-  "SELECT RAW, \"Foo\", \"doNg\".\"bAr\", `king`.`doNg`.`feE` FROM `king`.`doNg`")
+  "SELECT RAW, \"Foo\", \"doNg\".\"bAr\", `king`.`doNg`.`feE` FROM `dIng`.`doNg`")
 
 ;; When case-insensitive matching is used on the mixed-case query, quotes are still preserved
 (def ^:private heavily-quoted-query-mixed-case-full-rewritten
@@ -248,9 +248,7 @@ from foo")
                                              :case-insensitive :agnostic
                                              :quotes-preserve-case? true))))
     (testing "Only matching identifiers are renamed when allowed to run partially"
-      ;; Note: `dIng` (capital I) in FROM doesn't match `ding` with quotes-preserve-case
-      ;; so only the column's schema (lowercase `ding`) gets renamed
-      (is (= "SELECT RAW, \"Foo\", \"doNg\".\"bAr\", `king`.`doNg`.`feE` FROM `dIng`.`doNg`"
+      (is (= heavily-quoted-query-mixed-case-rewritten
              (m/replace-names heavily-quoted-query-mixed-case
                               heavily-quoted-query-rewrites
                               {:case-insensitive      :agnostic


### PR DESCRIPTION
There was a bug where we were not flagging AST nodes as dirty where only their schema was updated.

Update: based on tests we fixed some other edges too