### PR TITLE
Demonstrate that rename is broken when CTEs have shadowing

### DIFF
--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -548,6 +548,25 @@ from foo")
                            :tables  {{:schema "public" :table "orders"} "purchases"}
                            :columns {{:schema "public" :table "orders" :column "x"} "xx"}}))))
 
+(def ^:private cte-before-replace
+  "WITH z AS (SELECT * FROM a)
+   SELECT c FROM z")
+
+(def ^:private cte-after-replace
+  "WITH z AS (SELECT * FROM b)
+   SELECT c FROM z")
+
+(deftest replace-within-cte-test
+  (is (= cte-after-replace
+         (m/replace-names cte-before-replace {:tables {{:table "a"} "b"}})))
+
+  ;; TODO fix this, which is broken due to shadowing
+  #_(testing "with shadowing"
+    (let [rr #(str/replace % "z" "a")]
+        (is (= (rr cte-after-replace)
+               (m/replace-names (rr cte-before-replace) {:tables {{:table "a"} "b"}}))))))
+
+
 (deftest allow-unused-test
   (is (thrown-with-msg?
        Exception #"Unknown rename"

--- a/test/macaw/core_test.clj
+++ b/test/macaw/core_test.clj
@@ -560,11 +560,15 @@ from foo")
   (is (= cte-after-replace
          (m/replace-names cte-before-replace {:tables {{:table "a"} "b"}})))
 
-  ;; TODO fix this, which is broken due to shadowing
-  #_(testing "with shadowing"
+  (testing "with shadowing"
     (let [rr #(str/replace % "z" "a")]
-        (is (= (rr cte-after-replace)
-               (m/replace-names (rr cte-before-replace) {:tables {{:table "a"} "b"}}))))))
+        ;; TODO fix this, which is broken due to shadowing
+        (is (= #_(rr cte-after-replace)
+             ;; We treat references to the table `a` as if they were references to the CTE, and therefore leave them.
+             (rr cte-before-replace)
+             (m/replace-names (rr cte-before-replace)
+                              {:tables {{:table "a"} "b"}}
+                              {:allow-unused? true}))))))
 
 
 (deftest allow-unused-test


### PR DESCRIPTION
Unfortunately the ->ast version can't round-trip.

This requires some non-trivial fixing, or we could do it in a trivial way if we spuriously rename the alias as well
